### PR TITLE
[refactor] Renamed aux package to resolve Windows issue

### DIFF
--- a/src/main/java/com/example/LlamaApp.java
+++ b/src/main/java/com/example/LlamaApp.java
@@ -1,7 +1,7 @@
 package com.example;
 
 import com.example.aot.AOT;
-import com.example.aux.ChatFormat;
+import com.example.auxiliary.ChatFormat;
 import com.example.core.model.tensor.FloatTensor;
 import com.example.inference.CategoricalSampler;
 import com.example.inference.Sampler;

--- a/src/main/java/com/example/aot/AOT.java
+++ b/src/main/java/com/example/aot/AOT.java
@@ -1,6 +1,6 @@
 package com.example.aot;
 
-import com.example.aux.Timer;
+import com.example.auxiliary.Timer;
 import com.example.core.model.GGUF;
 import com.example.core.model.tensor.GGMLTensorEntry;
 import com.example.inference.engine.impl.Llama;

--- a/src/main/java/com/example/auxiliary/ChatFormat.java
+++ b/src/main/java/com/example/auxiliary/ChatFormat.java
@@ -1,4 +1,4 @@
-package com.example.aux;
+package com.example.auxiliary;
 
 import com.example.tokenizer.impl.Tokenizer;
 

--- a/src/main/java/com/example/auxiliary/Parallel.java
+++ b/src/main/java/com/example/auxiliary/Parallel.java
@@ -1,4 +1,4 @@
-package com.example.aux;
+package com.example.auxiliary;
 
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;

--- a/src/main/java/com/example/auxiliary/Timer.java
+++ b/src/main/java/com/example/auxiliary/Timer.java
@@ -1,4 +1,4 @@
-package com.example.aux;
+package com.example.auxiliary;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/example/auxiliary/Tuple2.java
+++ b/src/main/java/com/example/auxiliary/Tuple2.java
@@ -1,4 +1,4 @@
-package com.example.aux;
+package com.example.auxiliary;
 
 public class Tuple2<T, U> {
     private final T first;

--- a/src/main/java/com/example/core/model/GGUF.java
+++ b/src/main/java/com/example/core/model/GGUF.java
@@ -1,6 +1,6 @@
 package com.example.core.model;
 
-import com.example.aux.Timer;
+import com.example.auxiliary.Timer;
 import com.example.core.model.tensor.FloatTensor;
 import com.example.core.model.tensor.GGMLTensorEntry;
 import com.example.core.types.MetadataValueType;

--- a/src/main/java/com/example/core/model/tensor/FloatTensor.java
+++ b/src/main/java/com/example/core/model/tensor/FloatTensor.java
@@ -1,6 +1,6 @@
 package com.example.core.model.tensor;
 
-import com.example.aux.Parallel;
+import com.example.auxiliary.Parallel;
 import com.example.core.model.GGMLType;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.VectorShape;

--- a/src/main/java/com/example/inference/engine/impl/Llama.java
+++ b/src/main/java/com/example/inference/engine/impl/Llama.java
@@ -1,6 +1,6 @@
 package com.example.inference.engine.impl;
 
-import com.example.aux.Parallel;
+import com.example.auxiliary.Parallel;
 import com.example.core.model.tensor.FloatTensor;
 import com.example.inference.Sampler;
 import com.example.loader.weights.State;

--- a/src/main/java/com/example/loader/weights/ModelLoader.java
+++ b/src/main/java/com/example/loader/weights/ModelLoader.java
@@ -1,7 +1,7 @@
 package com.example.loader.weights;
 
 import com.example.LlamaApp;
-import com.example.aux.Timer;
+import com.example.auxiliary.Timer;
 import com.example.core.model.GGMLType;
 import com.example.core.model.GGUF;
 import com.example.core.model.tensor.F16FloatTensor;

--- a/src/main/java/com/example/tornadovm/TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/TornadoVMLayerPlanner.java
@@ -1,6 +1,6 @@
 package com.example.tornadovm;
 
-import com.example.aux.Tuple2;
+import com.example.auxiliary.Tuple2;
 import com.example.inference.engine.impl.Configuration;
 import com.example.inference.engine.impl.Llama;
 import com.example.loader.weights.State;

--- a/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
+++ b/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
@@ -1,6 +1,6 @@
 package com.example.tornadovm;
 
-import com.example.aux.Tuple2;
+import com.example.auxiliary.Tuple2;
 import com.example.inference.engine.impl.Configuration;
 import com.example.inference.engine.impl.Llama;
 import com.example.loader.weights.State;


### PR DESCRIPTION
This PR renames the `aux` package in the examples to `auxiliary`, in order to avoid a conflict issue that is present in Windows because `aux` is a reserved keyword in Windows.