### PR TITLE
Windows support for GPULlama3.java

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ clean:
 # Package the project without running tests
 package:
 	mvn package -DskipTests
-	. ./set_paths
 
 
 # Combined clean and package

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ cd GPULlama3.java
 
 # Update the submodules to match the exact commit point recorded in this repository
 git submodule update --recursive
+```
 
+#### On Linux or macOS
+```bash
 # Enter the TornadoVM submodule directory
 cd external/tornadovm
 
@@ -110,9 +113,6 @@ source setvars.sh
 # Navigate back to the project root directory
 cd ../../
 
-# Make the llama-tornado script executable
-chmod +x llama-tornado
-
 # Source the project-specific environment paths -> this will ensure the correct paths are set for the project and the TornadoVM SDK
 # Expect to see: [INFO] Environment configured for Llama3 with TornadoVM at: /home/YOUR_PATH_TO_TORNADOVM
 source set_paths
@@ -123,6 +123,39 @@ make
 
 # Run the model (make sure you have downloaded the model file first -  see below)
 ./llama-tornado --gpu  --verbose-init --opencl --model beehive-llama-3.2-1b-instruct-fp16.gguf --prompt "tell me a joke"
+```
+
+#### On Windows
+```bash
+# Enter the TornadoVM submodule directory
+cd external/tornadovm
+
+# Optional: Create and activate a Python virtual environment if needed
+python -m venv .venv
+.venv\Scripts\activate.bat
+.\bin\windowsMicrosoftStudioTools2022.cmd
+
+# Install TornadoVM with a supported JDK 21 and select the backends (--backend opencl,ptx).
+# To see the compatible JDKs run: ./bin/tornadovm-installer --listJDKs
+# For example, to install with OpenJDK 21 and build the OpenCL backend, run: 
+python bin\tornadovm-installer --jdk jdk21 --backend opencl
+
+# Source the TornadoVM environment variables
+setvars.cmd
+
+# Navigate back to the project root directory
+cd ../../
+
+# Source the project-specific environment paths -> this will ensure the correct paths are set for the project and the TornadoVM SDK
+# Expect to see: [INFO] Environment configured for Llama3 with TornadoVM at: C:\Users\YOUR_PATH_TO_TORNADOVM
+set_paths.cmd
+
+# Build the project using Maven (skip tests for faster build)
+# mvn clean package -DskipTests or just make
+make
+
+# Run the model (make sure you have downloaded the model file first -  see below)
+python llama-tornado --gpu  --verbose-init --opencl --model beehive-llama-3.2-1b-instruct-fp16.gguf --prompt "tell me a joke"
 ```
 -----------
 
@@ -182,7 +215,7 @@ Run a model with a text prompt:
 #### GPU Execution (FP16 Model)
 Enable GPU acceleration with Q8_0 quantization:
 ```bash
-llama-tornado --gpu  --verbose-init --model beehive-llama-3.2-1b-instruct-fp16.gguf --prompt "tell me a joke"
+./llama-tornado --gpu  --verbose-init --model beehive-llama-3.2-1b-instruct-fp16.gguf --prompt "tell me a joke"
 ```
 
 -----------

--- a/llama-tornado
+++ b/llama-tornado
@@ -227,6 +227,41 @@ class LlamaRunner:
             print(f"Error: {e}")
             return 1
 
+def load_env_from_script():
+    system = platform.system()
+
+    if system == "Windows":
+        # Call set_paths.cmd and capture output as environment
+        result = subprocess.run(
+            ["cmd.exe", "/c", "set_paths.cmd && set"],
+            capture_output=True, text=True, shell=False
+        )
+        if result.returncode != 0:
+            print("Failed to run set_paths.cmd")
+            sys.exit(1)
+
+        # Parse environment variables from output
+        for line in result.stdout.splitlines():
+            if '=' in line:
+                key, value = line.strip().split('=', 1)
+                os.environ[key] = value
+
+    elif system in ("Linux", "Darwin"):
+        # Source the set_paths file and capture env
+        command = ['bash', '-c', 'source ./set_paths && env']
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            print("Failed to source set_paths")
+            sys.exit(1)
+
+        for line in result.stdout.splitlines():
+            if '=' in line:
+                key, value = line.strip().split('=', 1)
+                os.environ[key] = value
+    else:
+        print(f"Unsupported OS: {system}")
+        sys.exit(1)
+
 def create_parser() -> argparse.ArgumentParser:
     """Create and configure the argument parser."""
     parser = argparse.ArgumentParser(
@@ -323,6 +358,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 def main():
     """Main entry point."""
+    load_env_from_script()
     parser = create_parser()
     args = parser.parse_args()
 

--- a/llama-tornado
+++ b/llama-tornado
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import time
+import platform
 from pathlib import Path
 from typing import List, Optional, Dict, Any
 from enum import Enum
@@ -44,6 +45,11 @@ class LlamaRunner:
                 print(f"Error: {name} path does not exist: {path}")
                 sys.exit(1)
 
+    @staticmethod
+    def module_path_colon_sep(paths: List[str]) -> str:
+        """Return OS-specific separator for Java module paths."""
+        return ";".join(paths) if platform.system() == "Windows" else ":".join(paths)
+
     def _build_base_command(self, args: argparse.Namespace) -> List[str]:
         """Build the base Java command with JVM options."""
         cmd = [
@@ -56,7 +62,7 @@ class LlamaRunner:
             "--enable-preview",
             f"-Djava.library.path={self.tornado_sdk}/lib",
             "-Djdk.module.showModuleResolution=false",
-            "--module-path", f".:{self.tornado_sdk}/share/java/tornado",
+            "--module-path", self.module_path_colon_sep([".", f"{self.tornado_sdk}/share/java/tornado"]),
         ]
 
         # TornadoVM configuration

--- a/set_paths.cmd
+++ b/set_paths.cmd
@@ -1,0 +1,29 @@
+@echo off
+REM ============================================
+REM Environment setup script for LLaMA3 + TornadoVM (Windows)
+REM ============================================
+
+REM Resolve the absolute path to this script's directory
+set "LLAMA_ROOT=%~dp0"
+set "LLAMA_ROOT=%LLAMA_ROOT:~0,-1%"
+
+REM Set TornadoVM root and SDK paths
+set "TORNADO_ROOT=%LLAMA_ROOT%\external\tornadovm"
+set "TORNADO_SDK=%TORNADO_ROOT%\bin\sdk"
+
+REM Add TornadoVM SDK and LLaMA3 bin to PATH
+set "PATH=%TORNADO_SDK%;%LLAMA_ROOT%\bin;%PATH%"
+
+REM Optional: Set JAVA_HOME if needed
+REM set "JAVA_HOME=C:\Path\To\GraalVM"
+REM set "PATH=%JAVA_HOME%\bin;%PATH%"
+
+echo [INFO] Environment configured for LLaMA3 with TornadoVM at: %TORNADO_ROOT%
+
+REM ===== Notes =====
+REM After running this script:
+REM 1. TornadoVM will be available for GPU computation
+REM 2. LLaMA3 command-line tools will be in your PATH
+REM 3. You can run LLaMA3 with GPU acceleration using TornadoVM
+REM
+REM To use this script: call set_paths.cmd


### PR DESCRIPTION
This PR provides support and instructions to install and run on Windows OS. The changes included in this PR are listed below:

- `README`, update the installation part for Windows and removed unnecessary steps.
- Add a `set_paths.cmd` file for loading environment variables on Windows
- Updated the `llama-tornado` python program with: i) a fix for the path delimiter in Windows, and ii) loading the variables before launching the execution.

This is the trace after running on an NVIDIA GPU in Windows (no isolation mode):
```bash
python llama-tornado --gpu --verbose-init --opencl --model beehive-llama-3.2-1b-instruct-fp16.gguf --prompt "Tell me a joke"
WARNING: Using incubator modules: jdk.incubator.vector
Parse beehive-llama-3.2-1b-instruct-fp16.gguf: 1427 millis
Loading model weights in TornadoVM format (loading F16 -> F16)
Load LlaMa model: 2911 millis
Starting TornadoVM initialization...
TornadoVM GPU execution plan creation: 3117.03 ms
Java to GPU JIT compiler warmup: 3383.45 ms
Transfer read-only weights to GPU: 1043.90 ms
Finished TornadoVM initialization...

I'll try to come up with a clean one. Here's a joke: 

Why was the computer and the keyboard and the mouse all invited to the wedding? 

Because they were all already married. 

achieved tok/s: 19.62. Tokens: 54, seconds: 2.75
```