### PR TITLE
Add GUI Chatbox for GPULlama3.java Inference

### DIFF
--- a/llama-tornado
+++ b/llama-tornado
@@ -251,6 +251,9 @@ class LlamaRunner:
                 print(f"  {arg}")
             print()
 
+        if args.gui:
+            cmd.append("--gui")
+
         # Execute the command
         try:
             result = subprocess.run(cmd, check=True)
@@ -316,7 +319,8 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model",
         dest="model_path",
-        required=True,
+        required="--gui" not in sys.argv,
+        default="",
         help="Path to the LLM gguf file (e.g., Llama-3.2-1B-Instruct-Q8_0.gguf)",
     )
 
@@ -464,6 +468,12 @@ def create_parser() -> argparse.ArgumentParser:
     )
     advanced_group.add_argument(
         "--verbose", "-v", action="store_true", help="Verbose output"
+    )
+
+    # GUI options
+    gui_group = parser.add_argument_group("GUI Options")
+    gui_group.add_argument(
+        "--gui", action="store_true", help="Launch the GUI chatbox"
     )
 
     return parser

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>tornado-runtime</artifactId>
             <version>1.1.1-dev</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>21</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -67,6 +73,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <configuration>
+                    <mainClass>com.example.gui.LlamaChatbox</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>javafx-controls</artifactId>
             <version>21</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.github.mkpaz</groupId>
+            <artifactId>atlantafx-base</artifactId>
+            <version>2.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/LlamaApp.java
+++ b/src/main/java/com/example/LlamaApp.java
@@ -20,8 +20,28 @@ public class LlamaApp {
     // Configuration flags for hardware acceleration and optimizations
     public static final boolean USE_VECTOR_API = Boolean.parseBoolean(System.getProperty("llama.VectorAPI", "true"));   // Enable Java Vector API for CPU acceleration
     public static final boolean USE_AOT = Boolean.parseBoolean(System.getProperty("llama.AOT", "false"));               // Use Ahead-of-Time compilation
-    public static final boolean USE_TORNADOVM = Boolean.parseBoolean(System.getProperty("use.tornadovm", "false"));     // Use TornadoVM for GPU acceleration
+    private boolean useTornadoVM = Boolean.parseBoolean(System.getProperty("use.tornadovm", "false"));                  // Use TornadoVM for GPU acceleration
     public static final boolean SHOW_PERF_INTERACTIVE = Boolean.parseBoolean(System.getProperty("llama.ShowPerfInteractive", "true")); // Show performance metrics in interactive mode
+
+    private static LlamaApp instance;
+
+    private LlamaApp() {
+    }
+
+    public static LlamaApp getInstance() {
+        if (instance == null) {
+            instance = new LlamaApp();
+        }
+        return instance;
+    }
+
+    public void setUseTornadoVM(boolean value) {
+        useTornadoVM = value;
+    }
+
+    public boolean getUseTornadoVM() {
+        return useTornadoVM;
+    }
 
     /**
      * Creates and configures a sampler for token generation based on specified parameters.

--- a/src/main/java/com/example/LlamaApp.java
+++ b/src/main/java/com/example/LlamaApp.java
@@ -120,7 +120,7 @@ public class LlamaApp {
      * @throws IOException if the model fails to load
      * @throws IllegalStateException if AOT loading is enabled but the preloaded model is unavailable
      */
-    private static Model loadModel(Options options) throws IOException {
+    public static Model loadModel(Options options) throws IOException {
         if (USE_AOT) {
             Model model = AOT.tryUsePreLoaded(options.modelPath(), options.maxTokens());
             if (model == null) {
@@ -131,7 +131,7 @@ public class LlamaApp {
         return ModelLoader.loadModel(options.modelPath(), options.maxTokens(), true);
     }
 
-    private static Sampler createSampler(Model model, Options options) {
+    public static Sampler createSampler(Model model, Options options) {
         return selectSampler(model.configuration().vocabularySize(), options.temperature(), options.topp(), options.seed());
     }
 

--- a/src/main/java/com/example/LlamaApp.java
+++ b/src/main/java/com/example/LlamaApp.java
@@ -2,12 +2,14 @@ package com.example;
 
 import com.example.aot.AOT;
 import com.example.core.model.tensor.FloatTensor;
+import com.example.gui.LlamaChatbox;
 import com.example.inference.sampler.CategoricalSampler;
 import com.example.inference.sampler.Sampler;
 import com.example.inference.sampler.ToppSampler;
 import com.example.loader.weights.ModelLoader;
 import com.example.model.Model;
 import com.example.tornadovm.FloatArrayUtils;
+import javafx.application.Application;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 import java.io.IOException;
@@ -145,13 +147,20 @@ public class LlamaApp {
      */
     public static void main(String[] args) throws IOException {
         Options options = Options.parseOptions(args);
-        Model model = loadModel(options);
-        Sampler sampler = createSampler(model, options);
 
-        if (options.interactive()) {
-            model.runInteractive(sampler, options);
+        if (options.guiMode()) {
+            // Launch the JavaFX application
+            Application.launch(LlamaChatbox.class, args);
         } else {
-            model.runInstructOnce(sampler, options);
+            // Run the CLI logic
+            Model model = loadModel(options);
+            Sampler sampler = createSampler(model, options);
+
+            if (options.interactive()) {
+                model.runInteractive(sampler, options);
+            } else {
+                model.runInstructOnce(sampler, options);
+            }
         }
     }
 }

--- a/src/main/java/com/example/Options.java
+++ b/src/main/java/com/example/Options.java
@@ -5,7 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public record Options(Path modelPath, String prompt, String systemPrompt, String suffix, boolean interactive,
-                      float temperature, float topp, long seed, int maxTokens, boolean stream, boolean echo) {
+                      float temperature, float topp, long seed, int maxTokens, boolean stream, boolean echo, boolean guiMode) {
 
     public static final int DEFAULT_MAX_TOKENS = 1024;
 
@@ -41,6 +41,7 @@ public record Options(Path modelPath, String prompt, String systemPrompt, String
         out.println("  --max-tokens, -n <int>        number of steps to run for < 0 = limited by context length, default " + DEFAULT_MAX_TOKENS);
         out.println("  --stream <boolean>            print tokens during generation; may cause encoding artifacts for non ASCII text, default true");
         out.println("  --echo <boolean>              print ALL tokens to stderr, if true, recommended to set --stream=false, default false");
+        out.println("  --gui <boolean>               run the GUI chatbox");
         out.println();
     }
 
@@ -57,6 +58,7 @@ public record Options(Path modelPath, String prompt, String systemPrompt, String
         boolean interactive = false;
         boolean stream = true;
         boolean echo = false;
+        boolean guiMode = false;
 
         for (int i = 0; i < args.length; i++) {
             String optionName = args[i];
@@ -64,6 +66,7 @@ public record Options(Path modelPath, String prompt, String systemPrompt, String
             switch (optionName) {
                 case "--interactive", "--chat", "-i" -> interactive = true;
                 case "--instruct" -> interactive = false;
+                case "--gui" -> guiMode = true;
                 case "--help", "-h" -> {
                     printUsage(System.out);
                     System.exit(0);
@@ -95,6 +98,6 @@ public record Options(Path modelPath, String prompt, String systemPrompt, String
                 }
             }
         }
-        return new Options(modelPath, prompt, systemPrompt, suffix, interactive, temperature, topp, seed, maxTokens, stream, echo);
+        return new Options(modelPath, prompt, systemPrompt, suffix, interactive, temperature, topp, seed, maxTokens, stream, echo, guiMode);
     }
 }

--- a/src/main/java/com/example/gui/ChatboxController.java
+++ b/src/main/java/com/example/gui/ChatboxController.java
@@ -1,0 +1,27 @@
+package com.example.gui;
+
+import javafx.scene.layout.Region;
+
+public class ChatboxController {
+
+    private final ChatboxViewBuilder viewBuilder;
+    private final ChatboxInteractor interactor;
+
+    public ChatboxController() {
+        ChatboxModel model = new ChatboxModel();
+        interactor = new ChatboxInteractor(model);
+        viewBuilder = new ChatboxViewBuilder(model, this::runInference);
+    }
+
+    private void runInference(Runnable postRunAction) {
+        // TODO: Run llama tornado
+        System.out.println("Starting LLM inference.");
+        interactor.runLlamaTornado();
+        postRunAction.run();
+    }
+
+    public Region getView() {
+        return viewBuilder.build();
+    }
+
+}

--- a/src/main/java/com/example/gui/ChatboxController.java
+++ b/src/main/java/com/example/gui/ChatboxController.java
@@ -1,5 +1,6 @@
 package com.example.gui;
 
+import javafx.concurrent.Task;
 import javafx.scene.layout.Region;
 
 public class ChatboxController {
@@ -14,10 +15,18 @@ public class ChatboxController {
     }
 
     private void runInference(Runnable postRunAction) {
-        // TODO: Run llama tornado
-        System.out.println("Starting LLM inference.");
-        interactor.runLlamaTornado();
-        postRunAction.run();
+        Task<Void> inferenceTask = new Task<>() {
+            @Override
+            protected Void call() {
+                interactor.runLlamaTornado();
+                return null;
+            }
+        };
+        inferenceTask.setOnSucceeded(evt -> {
+            postRunAction.run();
+        });
+        Thread inferenceThread = new Thread(inferenceTask);
+        inferenceThread.start();
     }
 
     public Region getView() {

--- a/src/main/java/com/example/gui/ChatboxInteractor.java
+++ b/src/main/java/com/example/gui/ChatboxInteractor.java
@@ -23,9 +23,11 @@ public class ChatboxInteractor {
         List<String> commands = new ArrayList<>();
 
         ChatboxModel.Engine engine = model.getSelectedEngine();
+        LlamaApp llamaApp = LlamaApp.getInstance();
         if (engine == ChatboxModel.Engine.TORNADO_VM) {
-            // TODO: LlamaApp.USE_TORNADOVM is a final constant, but the GUI needs to be able to set this value
-            //commands.add("--gpu");
+            llamaApp.setUseTornadoVM(true);
+        } else {
+            llamaApp.setUseTornadoVM(false);
         }
 
         ChatboxModel.Mode mode = model.getSelectedMode();

--- a/src/main/java/com/example/gui/ChatboxInteractor.java
+++ b/src/main/java/com/example/gui/ChatboxInteractor.java
@@ -1,5 +1,12 @@
 package com.example.gui;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class ChatboxInteractor {
 
     private final ChatboxModel model;
@@ -8,16 +15,75 @@ public class ChatboxInteractor {
         this.model = viewModel;
     }
 
-    // TODO: Business logic for running inference and updating the output display
+    // Run the 'llama-tornado' script in the given Llama3 path, and stream its output to the GUI's output area.
     public void runLlamaTornado() {
-        String output = String.format("Engine: %s\nLlama3 Path: %s\nModel: %s\nPrompt: %s\n",
-                model.getSelectedEngine(),
-                model.getLlama3Path(),
-                model.getSelectedModel(),
-                model.getPromptText()
-        );
-        System.out.printf(output);
-        model.setOutputText(output);
+        List<String> commands = new ArrayList<>();
+
+        String llama3Path = model.getLlama3Path();
+        if (llama3Path == null || llama3Path.isEmpty()) {
+            model.setOutputText("Please set the Llama3 path:");
+            return;
+        }
+
+        // Format for running 'llama-tornado' depends on the operating system.
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            commands.add(String.format("%s\\external\\tornadovm\\.venv\\Scripts\\python", llama3Path));
+            commands.add("llama-tornado");
+        } else {
+            commands.add(String.format("%s/.llama-tornado", llama3Path));
+        }
+
+        ChatboxModel.Engine engine = model.getSelectedEngine();
+        if (engine == ChatboxModel.Engine.TORNADO_VM) {
+            commands.add("--gpu");
+        }
+
+        // Assume that models are found in a /models directory.
+        String selectedModel = model.getSelectedModel();
+        if (selectedModel == null || selectedModel.isEmpty()) {
+            model.setOutputText("Please select a model.");
+            return;
+        }
+        String modelPath = String.format("%s/models/%s", llama3Path, selectedModel);
+        String prompt = String.format("\"%s\"", model.getPromptText());
+
+        commands.addAll(Arrays.asList(
+                "--model", modelPath,
+                "--prompt", prompt
+        ));
+
+        ProcessBuilder processBuilder = new ProcessBuilder(commands);
+        processBuilder.redirectErrorStream(true);
+        BufferedReader bufferedReader = null;
+        Process process;
+        try {
+            process = processBuilder.start();
+            bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            StringBuilder builder = new StringBuilder();
+
+            // Make sure to output the raw command.
+            builder.append("Running command: ");
+            builder.append(String.join(" ", processBuilder.command().toArray(new String[0])));
+            builder.append(System.getProperty("line.separator"));
+
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                builder.append(line);
+                builder.append(System.getProperty("line.separator"));
+                final String currentOutput = builder.toString();
+                javafx.application.Platform.runLater(() -> model.setOutputText(currentOutput));
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (bufferedReader != null) {
+                try {
+                    bufferedReader.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 
 }

--- a/src/main/java/com/example/gui/ChatboxInteractor.java
+++ b/src/main/java/com/example/gui/ChatboxInteractor.java
@@ -19,18 +19,12 @@ public class ChatboxInteractor {
     public void runLlamaTornado() {
         List<String> commands = new ArrayList<>();
 
-        String llama3Path = model.getLlama3Path();
-        if (llama3Path == null || llama3Path.isEmpty()) {
-            model.setOutputText("Please set the Llama3 path:");
-            return;
-        }
-
         // Format for running 'llama-tornado' depends on the operating system.
         if (System.getProperty("os.name").startsWith("Windows")) {
-            commands.add(String.format("%s\\external\\tornadovm\\.venv\\Scripts\\python", llama3Path));
+            commands.add("external\\tornadovm\\.venv\\Scripts\\python");
             commands.add("llama-tornado");
         } else {
-            commands.add(String.format("%s/.llama-tornado", llama3Path));
+            commands.add("llama-tornado");
         }
 
         ChatboxModel.Engine engine = model.getSelectedEngine();
@@ -44,7 +38,7 @@ public class ChatboxInteractor {
             model.setOutputText("Please select a model.");
             return;
         }
-        String modelPath = String.format("%s/models/%s", llama3Path, selectedModel);
+        String modelPath = String.format("./models/%s", selectedModel);
         String prompt = String.format("\"%s\"", model.getPromptText());
 
         commands.addAll(Arrays.asList(

--- a/src/main/java/com/example/gui/ChatboxInteractor.java
+++ b/src/main/java/com/example/gui/ChatboxInteractor.java
@@ -1,0 +1,23 @@
+package com.example.gui;
+
+public class ChatboxInteractor {
+
+    private final ChatboxModel model;
+
+    public ChatboxInteractor(ChatboxModel viewModel) {
+        this.model = viewModel;
+    }
+
+    // TODO: Business logic for running inference and updating the output display
+    public void runLlamaTornado() {
+        String output = String.format("Engine: %s\nLlama3 Path: %s\nModel: %s\nPrompt: %s\n",
+                model.getSelectedEngine(),
+                model.getLlama3Path(),
+                model.getSelectedModel(),
+                model.getPromptText()
+        );
+        System.out.printf(output);
+        model.setOutputText(output);
+    }
+
+}

--- a/src/main/java/com/example/gui/ChatboxInteractor.java
+++ b/src/main/java/com/example/gui/ChatboxInteractor.java
@@ -28,6 +28,11 @@ public class ChatboxInteractor {
             //commands.add("--gpu");
         }
 
+        ChatboxModel.Mode mode = model.getSelectedMode();
+        if (mode == ChatboxModel.Mode.INTERACTIVE) {
+            commands.add("--interactive");
+        }
+
         // Assume that models are found in a /models directory.
         String selectedModel = model.getSelectedModel();
         if (selectedModel == null || selectedModel.isEmpty()) {
@@ -91,6 +96,7 @@ public class ChatboxInteractor {
             Model llm = LlamaApp.loadModel(options);
             Sampler sampler = LlamaApp.createSampler(llm, options);
             if (options.interactive()) {
+                // TODO: how to read input from GUI text field?
                 llm.runInteractive(sampler, options);
             } else {
                 llm.runInstructOnce(sampler, options);

--- a/src/main/java/com/example/gui/ChatboxModel.java
+++ b/src/main/java/com/example/gui/ChatboxModel.java
@@ -23,7 +23,7 @@ public class ChatboxModel {
         return selectedEngine;
     }
 
-    public void setSelectedEngine(Engine engine){
+    public void setSelectedEngine(Engine engine) {
         this.selectedEngine.set(engine);
     }
 

--- a/src/main/java/com/example/gui/ChatboxModel.java
+++ b/src/main/java/com/example/gui/ChatboxModel.java
@@ -1,6 +1,8 @@
 package com.example.gui;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -15,6 +17,7 @@ public class ChatboxModel {
     private final StringProperty selectedModel = new SimpleStringProperty("");
     private final StringProperty promptText = new SimpleStringProperty("");
     private final StringProperty outputText = new SimpleStringProperty("");
+    private final BooleanProperty interactiveSessionActive = new SimpleBooleanProperty(false);
 
     public Engine getSelectedEngine() {
         return selectedEngine.get();
@@ -74,6 +77,18 @@ public class ChatboxModel {
 
     public void setOutputText(String text) {
         this.outputText.set(text);
+    }
+
+    public boolean getInteractiveSessionActive() {
+        return interactiveSessionActive.get();
+    }
+
+    public BooleanProperty interactiveSessionActiveProperty() {
+        return interactiveSessionActive;
+    }
+
+    public void setInteractiveSessionActive(boolean value) {
+        this.interactiveSessionActive.set(value);
     }
 
 }

--- a/src/main/java/com/example/gui/ChatboxModel.java
+++ b/src/main/java/com/example/gui/ChatboxModel.java
@@ -10,7 +10,6 @@ public class ChatboxModel {
     public enum Engine { TORNADO_VM, JVM }
 
     private final ObjectProperty<Engine> selectedEngine = new SimpleObjectProperty<>(Engine.TORNADO_VM);
-    private final StringProperty llama3Path = new SimpleStringProperty("");
     private final StringProperty selectedModel = new SimpleStringProperty("");
     private final StringProperty promptText = new SimpleStringProperty("");
     private final StringProperty outputText = new SimpleStringProperty("");
@@ -25,18 +24,6 @@ public class ChatboxModel {
 
     public void setSelectedEngine(Engine engine) {
         this.selectedEngine.set(engine);
-    }
-
-    public String getLlama3Path() {
-        return llama3Path.get();
-    }
-
-    public StringProperty llama3PathProperty() {
-        return llama3Path;
-    }
-
-    public void setLlama3Path(String path) {
-        this.llama3Path.set(path);
     }
 
     public String getSelectedModel() {

--- a/src/main/java/com/example/gui/ChatboxModel.java
+++ b/src/main/java/com/example/gui/ChatboxModel.java
@@ -1,0 +1,78 @@
+package com.example.gui;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+public class ChatboxModel {
+
+    public enum Engine { TORNADO_VM, JVM }
+
+    private final ObjectProperty<Engine> selectedEngine = new SimpleObjectProperty<>(Engine.TORNADO_VM);
+    private final StringProperty llama3Path = new SimpleStringProperty("");
+    private final StringProperty selectedModel = new SimpleStringProperty("");
+    private final StringProperty promptText = new SimpleStringProperty("");
+    private final StringProperty outputText = new SimpleStringProperty("");
+
+    public Engine getSelectedEngine() {
+        return selectedEngine.get();
+    }
+
+    public ObjectProperty<Engine> selectedEngineProperty() {
+        return selectedEngine;
+    }
+
+    public void setSelectedEngine(Engine engine){
+        this.selectedEngine.set(engine);
+    }
+
+    public String getLlama3Path() {
+        return llama3Path.get();
+    }
+
+    public StringProperty llama3PathProperty() {
+        return llama3Path;
+    }
+
+    public void setLlama3Path(String path) {
+        this.llama3Path.set(path);
+    }
+
+    public String getSelectedModel() {
+        return selectedModel.get();
+    }
+
+    public StringProperty selectedModelProperty() {
+        return selectedModel;
+    }
+
+    public void setSelectedModel(String selectedModel) {
+        this.selectedModel.set(selectedModel);
+    }
+
+    public String getPromptText() {
+        return promptText.get();
+    }
+
+    public StringProperty promptTextProperty() {
+        return promptText;
+    }
+
+    public void setPromptText(String text) {
+        this.promptText.set(text);
+    }
+
+    public String getOutputText() {
+        return outputText.get();
+    }
+
+    public StringProperty outputTextProperty() {
+        return outputText;
+    }
+
+    public void setOutputText(String text) {
+        this.outputText.set(text);
+    }
+
+}

--- a/src/main/java/com/example/gui/ChatboxModel.java
+++ b/src/main/java/com/example/gui/ChatboxModel.java
@@ -8,8 +8,10 @@ import javafx.beans.property.StringProperty;
 public class ChatboxModel {
 
     public enum Engine { TORNADO_VM, JVM }
+    public enum Mode { INSTRUCT, INTERACTIVE }
 
     private final ObjectProperty<Engine> selectedEngine = new SimpleObjectProperty<>(Engine.TORNADO_VM);
+    private final ObjectProperty<Mode> selectedMode = new SimpleObjectProperty<>(Mode.INSTRUCT);
     private final StringProperty selectedModel = new SimpleStringProperty("");
     private final StringProperty promptText = new SimpleStringProperty("");
     private final StringProperty outputText = new SimpleStringProperty("");
@@ -24,6 +26,18 @@ public class ChatboxModel {
 
     public void setSelectedEngine(Engine engine) {
         this.selectedEngine.set(engine);
+    }
+
+    public Mode getSelectedMode() {
+        return selectedMode.get();
+    }
+
+    public ObjectProperty<Mode> selectedModeProperty() {
+        return selectedMode;
+    }
+
+    public void setSelectedMode(Mode mode) {
+        this.selectedMode.set(mode);
     }
 
     public String getSelectedModel() {

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -15,8 +15,10 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.stage.DirectoryChooser;
 import javafx.util.Builder;
 
+import java.io.File;
 import java.util.function.Consumer;
 
 public class ChatboxViewBuilder implements Builder<Region> {
@@ -76,9 +78,13 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createLlama3PathBox() {
         Button browseButton = new Button("Browse");
-        // TODO: Browse directory
         browseButton.setOnAction(e -> {
-            System.out.println("Browse pressed!");
+            DirectoryChooser dirChooser = new DirectoryChooser();
+            dirChooser.setTitle("Select GPULlama3.java Directory");
+            File selectedDir = dirChooser.showDialog(browseButton.getScene().getWindow());
+            if (selectedDir != null) {
+                model.setLlama3Path(selectedDir.getAbsolutePath());
+            }
         });
 
         TextField pathField = boundTextField(model.llama3PathProperty());

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -30,7 +30,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
     }
 
     @Override
-    public Region build(){
+    public Region build() {
         VBox results = new VBox();
         results.setPrefWidth(800);
         results.setPrefHeight(600);
@@ -120,9 +120,8 @@ public class ChatboxViewBuilder implements Builder<Region> {
         Button runButton = new Button("Run");
         runButton.setMaxWidth(Double.MAX_VALUE);
         runButton.setOnAction(e -> {
-            // TODO: Run inference
-            System.out.println("Run pressed!");
-            actionHandler.accept(() -> System.out.println("Finished running inference."));
+            runButton.setDisable(true);
+            actionHandler.accept(() -> runButton.setDisable(false));
         });
         return runButton;
     }

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -9,8 +9,8 @@ import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Control;
 import javafx.scene.control.Label;
-import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
@@ -25,6 +25,8 @@ import java.util.function.Consumer;
 
 public class ChatboxViewBuilder implements Builder<Region> {
 
+    private static final int PANEL_WIDTH = 640;
+
     private final ChatboxModel model;
     private final BooleanProperty inferenceRunning = new SimpleBooleanProperty(false);
     private final Consumer<Runnable> actionHandler;
@@ -37,33 +39,28 @@ public class ChatboxViewBuilder implements Builder<Region> {
     @Override
     public Region build() {
         VBox results = new VBox();
-        results.setPrefWidth(800);
-        results.setPrefHeight(600);
 
-        SplitPane panels = new SplitPane();
+        HBox panels = new HBox(createLeftPanel(), createRightPanel());
         VBox.setVgrow(panels, Priority.ALWAYS);
         results.getChildren().add(panels);
-
-        panels.getItems().addAll(
-                createLeftPanel(),
-                createRightPanel()
-        );
 
         return results;
     }
 
     private Node createLeftPanel() {
         VBox panel = new VBox(12);
+        panel.setPrefWidth(PANEL_WIDTH);
         panel.setPadding(new Insets(24));
+        HBox.setHgrow(panel, Priority.ALWAYS);
         panel.getChildren().addAll(
                 createHeaderLabel("TornadoVM Chat"),
                 createEngineBox(),
                 createLlama3PathBox(),
                 createModelSelectBox(),
-                new Label("Prompt:"),
+                createLabel("Prompt:"),
                 createPromptBox(),
                 createRunButton(),
-                new Label("Output:"),
+                createLabel("Output:"),
                 createOutputArea()
         );
         return panel;
@@ -74,13 +71,14 @@ public class ChatboxViewBuilder implements Builder<Region> {
         engineDropdown.valueProperty().bindBidirectional(model.selectedEngineProperty());
         engineDropdown.getItems().addAll(ChatboxModel.Engine.values());
         engineDropdown.setMaxWidth(Double.MAX_VALUE);
-        HBox box = new HBox(8, new Label("Engine:"), engineDropdown);
+        HBox box = new HBox(8, createLabel("Engine:"), engineDropdown);
         box.setAlignment(Pos.CENTER_LEFT);
         return box;
     }
 
     private Node createLlama3PathBox() {
         Button browseButton = new Button("Browse");
+        browseButton.setMinWidth(80);
         browseButton.disableProperty().bind(inferenceRunning);
         browseButton.setOnAction(e -> {
             DirectoryChooser dirChooser = new DirectoryChooser();
@@ -92,7 +90,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
         });
 
         TextField pathField = boundTextField(model.llama3PathProperty());
-        HBox box = new HBox(8, new Label("Llama3 Path:"), pathField, browseButton);
+        HBox box = new HBox(8, createLabel("Llama3 Path:"), pathField, browseButton);
         box.setAlignment(Pos.CENTER_LEFT);
         HBox.setHgrow(pathField, Priority.ALWAYS);
         pathField.setMaxWidth(Double.MAX_VALUE);
@@ -107,6 +105,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
         modelDropdown.setMaxWidth(Double.MAX_VALUE);
 
         Button reloadButton = new Button("Reload");
+        reloadButton.setMinWidth(80);
         reloadButton.disableProperty().bind(inferenceRunning);
         reloadButton.setOnAction(e -> {
             // Search the Llama3 path for a /models folder containing model files.
@@ -137,7 +136,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
             }
         });
 
-        HBox box = new HBox(8, new Label("Model:"), modelDropdown, reloadButton);
+        HBox box = new HBox(8, createLabel("Model:"), modelDropdown, reloadButton);
         box.setAlignment(Pos.CENTER_LEFT);
         return box;
     }
@@ -175,7 +174,9 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createRightPanel() {
         VBox panel = new VBox(8);
+        panel.setPrefWidth(PANEL_WIDTH);
         panel.setPadding(new Insets(24));
+        HBox.setHgrow(panel, Priority.ALWAYS);
         panel.getChildren().addAll(
                 createMonitorOutputArea(),
                 createMonitorOptionsPanel()
@@ -219,14 +220,21 @@ public class ChatboxViewBuilder implements Builder<Region> {
         return textField;
     }
 
-    private Label createHeaderLabel(String text) {
+    // Helper method to create Label objects with a minimum width
+    private Label createLabel(String text) {
         Label label = new Label(text);
+        label.setMinWidth(Control.USE_PREF_SIZE);
+        return label;
+    }
+
+    private Label createHeaderLabel(String text) {
+        Label label = createLabel(text);
         label.setStyle("-fx-font-size: 16pt; -fx-font-weight: bold;");
         return label;
     }
 
     private Label createSubHeaderLabel(String text) {
-        Label label = new Label(text);
+        Label label = createLabel(text);
         label.setStyle("-fx-font-size: 12pt; -fx-font-weight: bold;");
         return label;
     }

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -1,0 +1,196 @@
+package com.example.gui;
+
+import javafx.beans.property.StringProperty;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.SplitPane;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.util.Builder;
+
+import java.util.function.Consumer;
+
+public class ChatboxViewBuilder implements Builder<Region> {
+
+    private final ChatboxModel model;
+    private final Consumer<Runnable> actionHandler;
+
+    public ChatboxViewBuilder(ChatboxModel model, Consumer<Runnable> actionHandler) {
+        this.model = model;
+        this.actionHandler = actionHandler;
+    }
+
+    @Override
+    public Region build(){
+        VBox results = new VBox();
+        results.setPrefWidth(800);
+        results.setPrefHeight(600);
+
+        SplitPane panels = new SplitPane();
+        VBox.setVgrow(panels, Priority.ALWAYS);
+        results.getChildren().add(panels);
+
+        panels.getItems().addAll(
+                createLeftPanel(),
+                createRightPanel()
+        );
+
+        return results;
+    }
+
+    private Node createLeftPanel() {
+        VBox panel = new VBox(12);
+        panel.setPadding(new Insets(24));
+        panel.getChildren().addAll(
+                createHeaderLabel("TornadoVM Chat"),
+                createEngineBox(),
+                createLlama3PathBox(),
+                createModelSelectBox(),
+                new Label("Prompt:"),
+                createPromptBox(),
+                createRunButton(),
+                new Label("Output:"),
+                createOutputArea()
+        );
+        return panel;
+    }
+
+    private Node createEngineBox() {
+        ComboBox<ChatboxModel.Engine> engineDropdown = new ComboBox<>();
+        engineDropdown.valueProperty().bindBidirectional(model.selectedEngineProperty());
+        engineDropdown.getItems().addAll(ChatboxModel.Engine.values());
+        engineDropdown.setMaxWidth(Double.MAX_VALUE);
+        HBox box = new HBox(8, new Label("Engine:"), engineDropdown);
+        box.setAlignment(Pos.CENTER_LEFT);
+        return box;
+    }
+
+    private Node createLlama3PathBox() {
+        Button browseButton = new Button("Browse");
+        // TODO: Browse directory
+        browseButton.setOnAction(e -> {
+            System.out.println("Browse pressed!");
+        });
+
+        TextField pathField = boundTextField(model.llama3PathProperty());
+        HBox box = new HBox(8, new Label("Llama3 Path:"), pathField, browseButton);
+        box.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(pathField, Priority.ALWAYS);
+        pathField.setMaxWidth(Double.MAX_VALUE);
+
+        return box;
+    }
+
+    private Node createModelSelectBox() {
+        ComboBox<String> modelDropdown = new ComboBox<>();
+        modelDropdown.valueProperty().bindBidirectional(model.selectedModelProperty());
+        // TODO: Update dropdown menu options when Llama3 path changes
+        modelDropdown.getItems().addAll("Llama-3.2-1B-Instruct-Q8_0.gguf", "Qwen3-0.6B-Q8_0.gguf"); // Hard-coded example strings for now
+        HBox.setHgrow(modelDropdown, Priority.ALWAYS);
+        modelDropdown.setMaxWidth(Double.MAX_VALUE);
+
+        Button reloadButton = new Button("Reload");
+        reloadButton.setOnAction(e -> {
+            // TODO: Scan Llama3 path for models
+            System.out.println("Reload pressed!");
+        });
+
+        HBox box = new HBox(8, new Label("Model:"), modelDropdown, reloadButton);
+        box.setAlignment(Pos.CENTER_LEFT);
+        return box;
+    }
+
+    private Node createPromptBox() {
+        TextField promptField = boundTextField(model.promptTextProperty());
+        HBox.setHgrow(promptField, Priority.ALWAYS);
+        promptField.setMaxWidth(Double.MAX_VALUE);
+        return new HBox(8, promptField);
+    }
+
+    private Node createRunButton() {
+        Button runButton = new Button("Run");
+        runButton.setMaxWidth(Double.MAX_VALUE);
+        runButton.setOnAction(e -> {
+            // TODO: Run inference
+            System.out.println("Run pressed!");
+            actionHandler.accept(() -> System.out.println("Finished running inference."));
+        });
+        return runButton;
+    }
+
+    private Node createOutputArea() {
+        TextArea outputArea = new TextArea();
+        outputArea.setEditable(false);
+        outputArea.setWrapText(true);
+        VBox.setVgrow(outputArea, Priority.ALWAYS);
+        outputArea.textProperty().bind(model.outputTextProperty());
+        return outputArea;
+    }
+
+    private Node createRightPanel() {
+        VBox panel = new VBox(8);
+        panel.setPadding(new Insets(24));
+        panel.getChildren().addAll(
+                createMonitorOutputArea(),
+                createMonitorOptionsPanel()
+        );
+        return panel;
+    }
+
+    private TextArea createMonitorOutputArea() {
+        TextArea textArea = new TextArea();
+        textArea.setEditable(false);
+        textArea.setWrapText(true);
+        VBox.setVgrow(textArea, Priority.ALWAYS);
+        return textArea;
+    }
+
+    private Node createMonitorOptionsPanel() {
+        VBox box = new VBox();
+        box.setPadding(new Insets(8));
+        box.getChildren().addAll(
+                createSubHeaderLabel("System Monitor"),
+                createSystemMonitoringCheckBoxes()
+        );
+        return box;
+    }
+
+    private Node createSystemMonitoringCheckBoxes() {
+        HBox checkBoxes = new HBox(8);
+        checkBoxes.setAlignment(Pos.CENTER_LEFT);
+        checkBoxes.getChildren().addAll(
+                new CheckBox("htop"),
+                new CheckBox("nvtop"),
+                new CheckBox("GPU-Monitor")
+        );
+        return checkBoxes;
+    }
+
+    // Helper method for creating TextField objects with bound text property
+    private TextField boundTextField(StringProperty boundProperty) {
+        TextField textField = new TextField();
+        textField.textProperty().bindBidirectional(boundProperty);
+        return textField;
+    }
+
+    private Label createHeaderLabel(String text) {
+        Label label = new Label(text);
+        label.setStyle("-fx-font-size: 16pt; -fx-font-weight: bold;");
+        return label;
+    }
+
+    private Label createSubHeaderLabel(String text) {
+        Label label = new Label(text);
+        label.setStyle("-fx-font-size: 12pt; -fx-font-weight: bold;");
+        return label;
+    }
+}

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -159,7 +159,11 @@ public class ChatboxViewBuilder implements Builder<Region> {
         outputArea.setEditable(false);
         outputArea.setWrapText(true);
         VBox.setVgrow(outputArea, Priority.ALWAYS);
-        outputArea.textProperty().bind(model.outputTextProperty());
+        model.outputTextProperty().subscribe((newValue) -> {
+            outputArea.setText(newValue);
+            // Autoscroll the text area to the bottom.
+            outputArea.positionCaret(newValue.length());
+        });
         return outputArea;
     }
 

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -1,6 +1,7 @@
 package com.example.gui;
 
 import atlantafx.base.theme.Styles;
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
@@ -68,6 +69,9 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createEngineBox() {
         ComboBox<ChatboxModel.Engine> engineDropdown = new ComboBox<>();
+        engineDropdown.disableProperty().bind(Bindings.createBooleanBinding(() -> (inferenceRunning.get() || model.getInteractiveSessionActive()),
+                inferenceRunning,
+                model.interactiveSessionActiveProperty()));
         engineDropdown.valueProperty().bindBidirectional(model.selectedEngineProperty());
         engineDropdown.getItems().addAll(ChatboxModel.Engine.values());
         engineDropdown.setMaxWidth(Double.MAX_VALUE);
@@ -79,6 +83,9 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createChatModeBox() {
         ComboBox<ChatboxModel.Mode> modeDropdown = new ComboBox<>();
+        modeDropdown.disableProperty().bind(Bindings.createBooleanBinding(() -> (inferenceRunning.get() || model.getInteractiveSessionActive()),
+                inferenceRunning,
+                model.interactiveSessionActiveProperty()));
         modeDropdown.valueProperty().bindBidirectional(model.selectedModeProperty());
         modeDropdown.getItems().addAll(ChatboxModel.Mode.values());
         modeDropdown.setMaxWidth(Double.MAX_VALUE);
@@ -90,6 +97,9 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createModelSelectBox() {
         ComboBox<String> modelDropdown = new ComboBox<>();
+        modelDropdown.disableProperty().bind(Bindings.createBooleanBinding(() -> (inferenceRunning.get() || model.getInteractiveSessionActive()),
+                inferenceRunning,
+                model.interactiveSessionActiveProperty()));
         modelDropdown.valueProperty().bindBidirectional(model.selectedModelProperty());
         HBox.setHgrow(modelDropdown, Priority.ALWAYS);
         modelDropdown.setMaxWidth(Double.MAX_VALUE);
@@ -97,7 +107,9 @@ public class ChatboxViewBuilder implements Builder<Region> {
         Button reloadButton = new Button("Reload");
         reloadButton.getStyleClass().add(Styles.ACCENT);
         reloadButton.setMinWidth(80);
-        reloadButton.disableProperty().bind(inferenceRunning);
+        reloadButton.disableProperty().bind(Bindings.createBooleanBinding(() -> (inferenceRunning.get() || model.getInteractiveSessionActive()),
+                inferenceRunning,
+                model.interactiveSessionActiveProperty()));
         reloadButton.setOnAction(e -> {
             // Search for a /models folder containing model files.
             modelDropdown.getItems().clear();

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -1,5 +1,7 @@
 package com.example.gui;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -24,6 +26,7 @@ import java.util.function.Consumer;
 public class ChatboxViewBuilder implements Builder<Region> {
 
     private final ChatboxModel model;
+    private final BooleanProperty inferenceRunning = new SimpleBooleanProperty(false);
     private final Consumer<Runnable> actionHandler;
 
     public ChatboxViewBuilder(ChatboxModel model, Consumer<Runnable> actionHandler) {
@@ -78,6 +81,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createLlama3PathBox() {
         Button browseButton = new Button("Browse");
+        browseButton.disableProperty().bind(inferenceRunning);
         browseButton.setOnAction(e -> {
             DirectoryChooser dirChooser = new DirectoryChooser();
             dirChooser.setTitle("Select GPULlama3.java Directory");
@@ -103,6 +107,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
         modelDropdown.setMaxWidth(Double.MAX_VALUE);
 
         Button reloadButton = new Button("Reload");
+        reloadButton.disableProperty().bind(inferenceRunning);
         reloadButton.setOnAction(e -> {
             // Search the Llama3 path for a /models folder containing model files.
             modelDropdown.getItems().clear();
@@ -147,9 +152,10 @@ public class ChatboxViewBuilder implements Builder<Region> {
     private Node createRunButton() {
         Button runButton = new Button("Run");
         runButton.setMaxWidth(Double.MAX_VALUE);
+        runButton.disableProperty().bind(inferenceRunning);
         runButton.setOnAction(e -> {
-            runButton.setDisable(true);
-            actionHandler.accept(() -> runButton.setDisable(false));
+            inferenceRunning.set(true);
+            actionHandler.accept(() -> inferenceRunning.set(false));
         });
         return runButton;
     }

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -21,7 +21,6 @@ import javafx.scene.layout.VBox;
 import javafx.util.Builder;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.function.Consumer;
 
 public class ChatboxViewBuilder implements Builder<Region> {
@@ -71,6 +70,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
         engineDropdown.valueProperty().bindBidirectional(model.selectedEngineProperty());
         engineDropdown.getItems().addAll(ChatboxModel.Engine.values());
         engineDropdown.setMaxWidth(Double.MAX_VALUE);
+        engineDropdown.setPrefWidth(152);
         HBox box = new HBox(8, createLabel("Engine:"), engineDropdown);
         box.setAlignment(Pos.CENTER_LEFT);
         return box;

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -1,5 +1,6 @@
 package com.example.gui;
 
+import atlantafx.base.theme.Styles;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
@@ -78,6 +79,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createLlama3PathBox() {
         Button browseButton = new Button("Browse");
+        browseButton.getStyleClass().add(Styles.ACCENT);
         browseButton.setMinWidth(80);
         browseButton.disableProperty().bind(inferenceRunning);
         browseButton.setOnAction(e -> {
@@ -105,6 +107,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
         modelDropdown.setMaxWidth(Double.MAX_VALUE);
 
         Button reloadButton = new Button("Reload");
+        reloadButton.getStyleClass().add(Styles.ACCENT);
         reloadButton.setMinWidth(80);
         reloadButton.disableProperty().bind(inferenceRunning);
         reloadButton.setOnAction(e -> {
@@ -150,6 +153,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
 
     private Node createRunButton() {
         Button runButton = new Button("Run");
+        runButton.getStyleClass().add(Styles.ACCENT);
         runButton.setMaxWidth(Double.MAX_VALUE);
         runButton.disableProperty().bind(inferenceRunning);
         runButton.setOnAction(e -> {

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -51,7 +51,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
     private Node createLeftPanel() {
         VBox panel = new VBox(12);
         panel.setPrefWidth(PANEL_WIDTH);
-        panel.setPadding(new Insets(24));
+        panel.setPadding(new Insets(24, 12, 24, 24));
         HBox.setHgrow(panel, Priority.ALWAYS);
         panel.getChildren().addAll(
                 createHeaderLabel("TornadoVM Chat"),
@@ -179,7 +179,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
     private Node createRightPanel() {
         VBox panel = new VBox(8);
         panel.setPrefWidth(PANEL_WIDTH);
-        panel.setPadding(new Insets(24));
+        panel.setPadding(new Insets(24, 24, 24, 12));
         HBox.setHgrow(panel, Priority.ALWAYS);
         panel.getChildren().addAll(
                 createMonitorOutputArea(),

--- a/src/main/java/com/example/gui/ChatboxViewBuilder.java
+++ b/src/main/java/com/example/gui/ChatboxViewBuilder.java
@@ -55,6 +55,7 @@ public class ChatboxViewBuilder implements Builder<Region> {
         panel.getChildren().addAll(
                 createHeaderLabel("TornadoVM Chat"),
                 createEngineBox(),
+                createChatModeBox(),
                 createModelSelectBox(),
                 createLabel("Prompt:"),
                 createPromptBox(),
@@ -72,6 +73,17 @@ public class ChatboxViewBuilder implements Builder<Region> {
         engineDropdown.setMaxWidth(Double.MAX_VALUE);
         engineDropdown.setPrefWidth(152);
         HBox box = new HBox(8, createLabel("Engine:"), engineDropdown);
+        box.setAlignment(Pos.CENTER_LEFT);
+        return box;
+    }
+
+    private Node createChatModeBox() {
+        ComboBox<ChatboxModel.Mode> modeDropdown = new ComboBox<>();
+        modeDropdown.valueProperty().bindBidirectional(model.selectedModeProperty());
+        modeDropdown.getItems().addAll(ChatboxModel.Mode.values());
+        modeDropdown.setMaxWidth(Double.MAX_VALUE);
+        modeDropdown.setPrefWidth(152);
+        HBox box = new HBox(8, createLabel("Chat:"), modeDropdown);
         box.setAlignment(Pos.CENTER_LEFT);
         return box;
     }

--- a/src/main/java/com/example/gui/LlamaChatbox.java
+++ b/src/main/java/com/example/gui/LlamaChatbox.java
@@ -1,0 +1,25 @@
+package com.example.gui;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+public class LlamaChatbox extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        String javaVersion = System.getProperty("java.version");
+        String javafxVersion = System.getProperty("javafx.version");
+        Label l = new Label("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
+        Scene scene = new Scene(new StackPane(l), 640, 480);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch();
+    }
+
+}

--- a/src/main/java/com/example/gui/LlamaChatbox.java
+++ b/src/main/java/com/example/gui/LlamaChatbox.java
@@ -2,24 +2,20 @@ package com.example.gui;
 
 import javafx.application.Application;
 import javafx.scene.Scene;
-import javafx.scene.control.Label;
-import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 public class LlamaChatbox extends Application {
 
     @Override
     public void start(Stage stage) {
-        String javaVersion = System.getProperty("java.version");
-        String javafxVersion = System.getProperty("javafx.version");
-        Label l = new Label("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
-        Scene scene = new Scene(new StackPane(l), 640, 480);
+        ChatboxController controller = new ChatboxController();
+        Scene scene = new Scene(controller.getView(), 800, 600);
+        stage.setTitle("TornadoVM Chat");
         stage.setScene(scene);
         stage.show();
     }
 
     public static void main(String[] args) {
-        launch();
+        launch(args);
     }
-
 }

--- a/src/main/java/com/example/gui/LlamaChatbox.java
+++ b/src/main/java/com/example/gui/LlamaChatbox.java
@@ -1,5 +1,7 @@
 package com.example.gui;
 
+import atlantafx.base.theme.CupertinoDark;
+import atlantafx.base.theme.PrimerDark;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -8,6 +10,7 @@ public class LlamaChatbox extends Application {
 
     @Override
     public void start(Stage stage) {
+        Application.setUserAgentStylesheet(new CupertinoDark().getUserAgentStylesheet());
         ChatboxController controller = new ChatboxController();
         Scene scene = new Scene(controller.getView(), 800, 600);
         stage.setTitle("TornadoVM Chat");

--- a/src/main/java/com/example/gui/LlamaChatbox.java
+++ b/src/main/java/com/example/gui/LlamaChatbox.java
@@ -1,7 +1,6 @@
 package com.example.gui;
 
 import atlantafx.base.theme.CupertinoDark;
-import atlantafx.base.theme.PrimerDark;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;

--- a/src/main/java/com/example/loader/weights/ModelLoader.java
+++ b/src/main/java/com/example/loader/weights/ModelLoader.java
@@ -96,7 +96,8 @@ public final class ModelLoader {
         GGMLTensorEntry tokenEmbeddings = tensorEntries.get("token_embd.weight");
         GGMLTensorEntry outputWeight = tensorEntries.getOrDefault("output.weight", tokenEmbeddings);
 
-        if (LlamaApp.USE_TORNADOVM) {
+        LlamaApp llamaApp = LlamaApp.getInstance();
+        if (llamaApp.getUseTornadoVM()) {
             System.out.println("Loading model weights in TornadoVM format (loading " + outputWeight.ggmlType() + " -> " + GGMLType.F16 + ")");
             return createTornadoVMWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
         } else {

--- a/src/main/java/com/example/model/Model.java
+++ b/src/main/java/com/example/model/Model.java
@@ -135,6 +135,104 @@ public interface Model {
     }
 
     /**
+     * Model agnostic implementation for interactive GUI mode.
+     * Takes a single user input and returns the model's response, allowing the GUI to manage the chat loop.
+     *
+     * @param sampler The sampler for token generation
+     * @param options The inference options
+     * @param userText The user's input text
+     * @param previousResponse A Response object referencing an ongoing chat
+     * @return A Response object containing the model's output and updated state
+     */
+    default Response runInteractiveStep(Sampler sampler, Options options, String userText, Response previousResponse) {
+        ChatFormat chatFormat = ChatFormat.create(tokenizer());
+        List<Integer> conversationTokens = previousResponse.conversationTokens();
+        State state = previousResponse.state();
+        TornadoVMMasterPlan tornadoVMPlan = previousResponse.tornadoVMPlan();
+        String responseText = "";
+
+        int startPosition = conversationTokens.size();
+
+        // For the first message, set up the conversation tokens if empty
+        if (conversationTokens.isEmpty()) {
+            conversationTokens.add(chatFormat.getBeginOfText());
+            if (options.systemPrompt() != null) {
+                conversationTokens.addAll(chatFormat.encodeMessage(new ChatFormat.Message(ChatFormat.Role.SYSTEM, options.systemPrompt())));
+            }
+        }
+
+        // Get the LlamaApp singleton to read configuration values
+        LlamaApp llamaApp = LlamaApp.getInstance();
+
+        if (state == null) {
+            // State allocation can take some time for large context sizes
+            state = createNewState();
+        }
+
+        // Initialize TornadoVM plan once at the beginning if GPU path is enabled
+        if (llamaApp.getUseTornadoVM() && tornadoVMPlan == null) {
+            tornadoVMPlan = TornadoVMMasterPlan.initializeTornadoVMPlan(state, this);
+        }
+
+        conversationTokens.addAll(chatFormat.encodeMessage(new ChatFormat.Message(ChatFormat.Role.USER, userText)));
+        conversationTokens.addAll(chatFormat.encodeHeader(new ChatFormat.Message(ChatFormat.Role.ASSISTANT, "")));
+        Set<Integer> stopTokens = chatFormat.getStopTokens();
+
+        List<Integer> responseTokens;
+        IntConsumer tokenConsumer = token -> {
+            if (options.stream()) {
+                if (tokenizer().shouldDisplayToken(token)) {
+                    System.out.print(tokenizer().decode(List.of(token)));
+                }
+            }
+        };
+
+        // Choose between GPU and CPU path based on configuration
+        if (llamaApp.getUseTornadoVM()) {
+            // GPU path using TornadoVM
+            responseTokens = InferenceEngine.generateTokensGPU(this, state, startPosition, conversationTokens.subList(startPosition, conversationTokens.size()), stopTokens,
+                    options.maxTokens(), sampler, options.echo(), options.stream() ? tokenConsumer : null, tornadoVMPlan);
+        } else {
+            // CPU path
+            responseTokens = InferenceEngine.generateTokens(this, state, startPosition, conversationTokens.subList(startPosition, conversationTokens.size()), stopTokens, options.maxTokens(),
+                    sampler, options.echo(), tokenConsumer);
+        }
+
+        // Include stop token in the prompt history, but not in the response displayed to the user.
+        conversationTokens.addAll(responseTokens);
+        Integer stopToken = null;
+        if (!responseTokens.isEmpty() && stopTokens.contains(responseTokens.getLast())) {
+            stopToken = responseTokens.getLast();
+            responseTokens.removeLast();
+        }
+        if (!options.stream()) {
+            responseText = tokenizer().decode(responseTokens);
+            System.out.println(responseText);
+        }
+        if (stopToken == null) {
+            System.err.println("\n Ran out of context length...\n Increase context length by passing to llama-tornado --max-tokens XXX");
+            return new Response(responseText, state, conversationTokens, tornadoVMPlan);
+        }
+        System.out.print("\n");
+
+        // Optionally print performance metrics after each response
+        if (SHOW_PERF_INTERACTIVE) {
+            LastRunMetrics.printMetrics();
+        }
+
+        return new Response(responseText, state, conversationTokens, tornadoVMPlan);
+    }
+
+    /**
+     * Simple data model for Model responses, used to keep track of conversation history and state.
+     */
+    record Response(String responseText, State state, List<Integer> conversationTokens, TornadoVMMasterPlan tornadoVMPlan)  {
+        public Response() {
+            this("", null, new ArrayList<>(), null);
+        }
+    }
+
+    /**
      * Model agnostic default implementation for instruct mode.
      * @param sampler
      * @param options


### PR DESCRIPTION
This PR adds a new JavaFX GUI for running inference with `GPULlama3` (for issue #24).

It adds a new package `com.example.gui` containing all the new classes for the chatbox GUI, following a Model-View-Controller-Interactor framework.

## Key Features

- Dropdown menu to select an engine (TornadoVM, JVM).
- Browse button to select the directory to the user's `GPULlama3.java` install.
- Dropdown menu and Reload button to search for models inside of a `/models` folder in the user's `GPULlama3.java` directory.
- Prompt text field for user input.
- Run button to trigger inference by running `llama-tornado` as a new process.
- Output area to display responses and other logs.

## How to Run

After following the "Install, Build, and Run" instructions from the README, run the following:

`mvn javafx:run`

## Notes

- Dark theme styling is from AtlantaFX.
- The right panel of the GUI is unfinished, but contains the System Monitoring panel with checkboxes (that do nothing), and an empty text area where the monitoring terminals would display.
- I'm using Windows, so Linux / macOS is untested.

## Next Steps

- I can try to add the system monitoring features, although I'm not sure how far I'll get since I'm on Windows, so I can't test `htop`, `nvtop` or any of the Linux-specific options as far as I know.
- Is the system monitoring display supposed to be embedded terminals? I did a bit of searching and found projects like TerminalFX and JediTermFX for this, but I don't know if that's the best way to implement this.