### PR TITLE
[models][phi-3] Support for Microsoft's Phi-3 models

### DIFF
--- a/src/main/java/com/example/inference/InferenceCore.java
+++ b/src/main/java/com/example/inference/InferenceCore.java
@@ -308,6 +308,10 @@ public final class InferenceCore {
         return state.logits;
     }
 
+    public static FloatTensor forwardJavaPhi3(Model model, State state, int token, int position) {
+        return null; // Placeholder for QPhi3 implementation
+    }
+
     /**
      * Performs the initial embedding lookup and triggers the TornadoVM accelerated forward pass for an LLM token.
      *

--- a/src/main/java/com/example/inference/InferenceCore.java
+++ b/src/main/java/com/example/inference/InferenceCore.java
@@ -372,7 +372,6 @@ public final class InferenceCore {
             int curLayer = l;
 
             // multihead attention. iterate over all heads
-            final int idxLayer = l;
             Parallel.parallelFor(0, config.numberOfHeads(), h -> {
                 // get the query vector for this head
                 // float* q = s.q + h * headSize;

--- a/src/main/java/com/example/inference/InferenceEngine.java
+++ b/src/main/java/com/example/inference/InferenceEngine.java
@@ -454,7 +454,91 @@ public final class InferenceEngine {
 
     public static List<Integer> generateTokensGPUPhi3(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
-        return null;
-    }
+        // === Setup and Initialization ===
+        long startNanos = System.nanoTime();
+        long inferenceStartNanos = 0;
+
+        // Pre-validate the max tokens to avoid checking in the loop
+        int actualMaxTokens = Math.min(maxTokens > 0 ? maxTokens : model.configuration().contextLength(), model.configuration().contextLength());
+
+        // Preallocate with expected capacity to avoid resizing
+        List<Integer> generatedTokens = new ArrayList<>(Math.min(256, actualMaxTokens - promptTokens.size())); // Conservative estimate
+
+        // === Token Generation Loop ===
+        int currentToken = state.latestToken;
+        int nextToken;
+        int promptIndex = 0;
+        int pos = startPosition;
+
+        // Use more efficient direct array access for prompt tokens if possible
+        int[] promptTokenArray = null;
+        if (promptTokens instanceof ArrayList) {
+            // Try to extract the underlying array for faster access
+            try {
+                // This is a performance optimization that may not work on all JVMs
+                promptTokenArray = promptTokens.stream().mapToInt(Integer::intValue).toArray();
+            } catch (Exception e) {
+                // Fall back to list access
+            }
+        }
+
+        // Main generation loop
+        while (pos < actualMaxTokens) {
+            // GPU Forward Pass - No conditional check since we know we're using GPU
+            //System.out.println("currentToken: " + currentToken);
+            FloatArray logits = InferenceCore.forwardTornadoVM(model, state, currentToken, pos, tornadoVMPlan);
+
+            // Process prompt tokens if still remaining
+            if (promptIndex < promptTokens.size()) {
+                // Get next prompt token (using array access if available)
+                nextToken = promptTokenArray != null ? promptTokenArray[promptIndex++] : promptTokens.get(promptIndex++);
+
+                if (echo) {
+                    // Decode and output token
+                    System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
+                }
+            } else {
+                // Mark first inference token
+                if (inferenceStartNanos == 0) {
+                    inferenceStartNanos = System.nanoTime();
+                }
+
+                // Sample next token - use GPU sampling if available
+                nextToken = sampler.sampleToken(logits);
+
+                // Add token consumer support
+                if (onTokenGenerated != null) {
+                    onTokenGenerated.accept(nextToken);
+                }
+
+                // Output if needed
+                if (echo && onTokenGenerated == null) {
+                    System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
+                }
+
+                // Store token
+                generatedTokens.add(nextToken);
+
+                // Check stop condition
+                if (stopTokens.contains(nextToken)) {
+                    break;
+                }
+            }
+
+            // Update for next iteration
+            currentToken = nextToken;
+            state.latestToken = currentToken;
+            pos++;
+        }
+
+        // === Performance Metrics ===
+        long endNanos = System.nanoTime();
+        double totalSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        int totalTokens = promptIndex + generatedTokens.size();
+
+        // Set metrics for tokens achieved
+        LastRunMetrics.setMetrics(totalTokens, totalSeconds);
+
+        return generatedTokens;    }
 
 }

--- a/src/main/java/com/example/inference/InferenceEngine.java
+++ b/src/main/java/com/example/inference/InferenceEngine.java
@@ -2,6 +2,7 @@ package com.example.inference;
 
 import com.example.auxiliary.LastRunMetrics;
 import com.example.inference.sampler.Sampler;
+import com.example.inference.state.Phi3State;
 import com.example.inference.state.State;
 import com.example.model.Configuration;
 import com.example.model.Model;

--- a/src/main/java/com/example/inference/InferenceEngine.java
+++ b/src/main/java/com/example/inference/InferenceEngine.java
@@ -19,8 +19,7 @@ import java.util.function.IntConsumer;
  * Main entry point for LLM token generation.
  *
  * <p>
- * Orchestrates the complete inference process: ingests prompt tokens, then generates
- * new tokens until a stop condition is met. Supports both CPU and GPU execution.
+ * Orchestrates the complete inference process: ingests prompt tokens, then generates new tokens until a stop condition is met. Supports both CPU and GPU execution.
  * </p>
  *
  * <p>
@@ -43,19 +42,26 @@ public final class InferenceEngine {
      * LLM generation entry point, ingest prompt tokens and generates new tokens.
      *
      * <p>
-     * All prompt tokens are ingested first, then inference starts, until a stop token is found.
-     * The returned tokens only include generated/inferred tokens.
+     * All prompt tokens are ingested first, then inference starts, until a stop token is found. The returned tokens only include generated/inferred tokens.
      *
-     * @param model            model to run inference (including weights, configuration, tokenizer ...)
-     * @param state            state of the model e.g. key/value caches ... this is mutated by this call
-     * @param startPosition    start prompt ingestion + inference at this position in the context e.g. useful if state was kept across calls (chained generation). 0 implies run with no previous context.
-     * @param promptTokens     prompt tokens to ingest, all the prompt tokens will be ingested, given there's enough capacity left in the context
-     * @param stopTokens       set of tokens that abort generation during inference, stop tokens do not affect prompt ingestion
-     * @param maxTokens        maximum number of tokens (can go up to {@link Configuration#contextLength context length}
-     *                         if this value is negative or greater than {@link Configuration#contextLength context length}
-     * @param sampler          {@link Sampler strategy} used to select tokens
-     * @param echo             debugging flag, prints ALL, prompt and inferred tokens, to {@link System#err stderr}
-     * @param onTokenGenerated callback, if non-null, it's called every time a token is inferred e.g. it's not called when ingesting prompt tokens
+     * @param model
+     *         model to run inference (including weights, configuration, tokenizer ...)
+     * @param state
+     *         state of the model e.g. key/value caches ... this is mutated by this call
+     * @param startPosition
+     *         start prompt ingestion + inference at this position in the context e.g. useful if state was kept across calls (chained generation). 0 implies run with no previous context.
+     * @param promptTokens
+     *         prompt tokens to ingest, all the prompt tokens will be ingested, given there's enough capacity left in the context
+     * @param stopTokens
+     *         set of tokens that abort generation during inference, stop tokens do not affect prompt ingestion
+     * @param maxTokens
+     *         maximum number of tokens (can go up to {@link Configuration#contextLength context length} if this value is negative or greater than {@link Configuration#contextLength context length}
+     * @param sampler
+     *         {@link Sampler strategy} used to select tokens
+     * @param echo
+     *         debugging flag, prints ALL, prompt and inferred tokens, to {@link System#err stderr}
+     * @param onTokenGenerated
+     *         callback, if non-null, it's called every time a token is inferred e.g. it's not called when ingesting prompt tokens
      * @return list of generated/inferred tokens, including the stop token, if any e.g. does not include any token from the prompt
      */
     public static List<Integer> generateTokensLlama(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
@@ -234,13 +240,9 @@ public final class InferenceEngine {
                 // Force-pick token from prompt.
                 nextToken = promptTokens.get(promptIndex++);
                 if (echo) {
-                    // log prompt token (different color?)
                     System.out.println("NextToken: " + nextToken);
-                    //System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
                     String decoded = model.tokenizer().decode(List.of(nextToken));
                     System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
-
-                    //                    System.err.print(de(decoded, baos));
                 }
             } else {
                 nextToken = sampler.sampleToken(state.logits);
@@ -262,9 +264,12 @@ public final class InferenceEngine {
             }
         }
 
-        long elapsedNanos = System.nanoTime() - startNanos;
+        // Calculate and print performance metrics
+        long endNanos = System.nanoTime();
+        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
         int totalTokens = promptIndex + generatedTokens.size();
-        System.err.printf("%n%.2f tokens/s (%d)%n", totalTokens / (elapsedNanos / 1_000_000_000.0), totalTokens);
+
+        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
 
         return generatedTokens;
 
@@ -451,95 +456,6 @@ public final class InferenceEngine {
 
         return generatedTokens;
     }
-
-//    public static List<Integer> generateTokensGPUPhi3(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
-//            IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
-//        // === Setup and Initialization ===
-//        long startNanos = System.nanoTime();
-//        long inferenceStartNanos = 0;
-//
-//        // Pre-validate the max tokens to avoid checking in the loop
-//        int actualMaxTokens = Math.min(maxTokens > 0 ? maxTokens : model.configuration().contextLength(), model.configuration().contextLength());
-//
-//        // Preallocate with expected capacity to avoid resizing
-//        List<Integer> generatedTokens = new ArrayList<>(Math.min(256, actualMaxTokens - promptTokens.size())); // Conservative estimate
-//
-//        // === Token Generation Loop ===
-//        int currentToken = state.latestToken;
-//        int nextToken;
-//        int promptIndex = 0;
-//        int pos = startPosition;
-//
-//        // Use more efficient direct array access for prompt tokens if possible
-//        int[] promptTokenArray = null;
-//        if (promptTokens instanceof ArrayList) {
-//            // Try to extract the underlying array for faster access
-//            try {
-//                // This is a performance optimization that may not work on all JVMs
-//                promptTokenArray = promptTokens.stream().mapToInt(Integer::intValue).toArray();
-//            } catch (Exception e) {
-//                // Fall back to list access
-//            }
-//        }
-//
-//        // Main generation loop
-//        while (pos < actualMaxTokens) {
-//            // GPU Forward Pass - No conditional check since we know we're using GPU
-//            //System.out.println("currentToken: " + currentToken);
-//            FloatArray logits = InferenceCore.forwardTornadoVM(model, state, currentToken, pos, tornadoVMPlan);
-//
-//            // Process prompt tokens if still remaining
-//            if (promptIndex < promptTokens.size()) {
-//                // Get next prompt token (using array access if available)
-//                nextToken = promptTokenArray != null ? promptTokenArray[promptIndex++] : promptTokens.get(promptIndex++);
-//
-//                if (echo) {
-//                    // Decode and output token
-//                    System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
-//                }
-//            } else {
-//                // Mark first inference token
-//                if (inferenceStartNanos == 0) {
-//                    inferenceStartNanos = System.nanoTime();
-//                }
-//
-//                // Sample next token - use GPU sampling if available
-//                nextToken = sampler.sampleToken(logits);
-//
-//                // Add token consumer support
-//                if (onTokenGenerated != null) {
-//                    onTokenGenerated.accept(nextToken);
-//                }
-//
-//                // Output if needed
-//                if (echo && onTokenGenerated == null) {
-//                    System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
-//                }
-//
-//                // Store token
-//                generatedTokens.add(nextToken);
-//
-//                // Check stop condition
-//                if (stopTokens.contains(nextToken)) {
-//                    break;
-//                }
-//            }
-//
-//            // Update for next iteration
-//            currentToken = nextToken;
-//            state.latestToken = currentToken;
-//            pos++;
-//        }
-//
-//        // === Performance Metrics ===
-//        long endNanos = System.nanoTime();
-//        double totalSeconds = (endNanos - startNanos) / 1_000_000_000.0;
-//        int totalTokens = promptIndex + generatedTokens.size();
-//
-//        // Set metrics for tokens achieved
-//        LastRunMetrics.setMetrics(totalTokens, totalSeconds);
-//
-//        return generatedTokens;    }
 
     public static List<Integer> generateTokensGPUPhi3(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {

--- a/src/main/java/com/example/inference/InferenceEngine.java
+++ b/src/main/java/com/example/inference/InferenceEngine.java
@@ -214,6 +214,11 @@ public final class InferenceEngine {
         return generatedTokens;
     }
 
+    public static List<Integer> generateTokensPhi3(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
+            IntConsumer onTokenGenerated) {
+        return null;
+    }
+
     public static List<Integer> generateTokensGPULlama(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
         // === Setup and Initialization ===
@@ -394,5 +399,10 @@ public final class InferenceEngine {
         LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
 
         return generatedTokens;
+    }
+
+    public static List<Integer> generateTokensGPUPhi3(Model model, State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
+            IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
+        return null;
     }
 }

--- a/src/main/java/com/example/inference/state/Phi3State.java
+++ b/src/main/java/com/example/inference/state/Phi3State.java
@@ -1,0 +1,20 @@
+package com.example.inference.state;
+
+import com.example.model.Configuration;
+
+public class Phi3State extends  State{
+    /**
+     * last index in previous block
+     *
+     * @param config
+     * @param batchsize
+     */
+    protected Phi3State(Configuration config, int batchsize) {
+        super(config, batchsize);
+    }
+
+    @Override
+    protected StateFields createStateFields(Configuration config) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/inference/state/Phi3State.java
+++ b/src/main/java/com/example/inference/state/Phi3State.java
@@ -9,7 +9,7 @@ public class Phi3State extends  State{
      * @param config
      * @param batchsize
      */
-    protected Phi3State(Configuration config, int batchsize) {
+    public Phi3State(Configuration config, int batchsize) {
         super(config, batchsize);
     }
 

--- a/src/main/java/com/example/inference/state/Phi3State.java
+++ b/src/main/java/com/example/inference/state/Phi3State.java
@@ -1,20 +1,102 @@
 package com.example.inference.state;
 
+import com.example.core.model.tensor.ArrayFloatTensor;
+import com.example.core.model.tensor.FloatTensor;
 import com.example.model.Configuration;
+import com.example.model.phi3.Phi3Configuration;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
-public class Phi3State extends  State{
-    /**
-     * last index in previous block
-     *
-     * @param config
-     * @param batchsize
-     */
+import java.util.stream.Stream;
+
+public class Phi3State extends State {
+    // Phi3-specific fields for QKV processing
+    public FloatTensor qkv; // Combined QKV buffer: op_size = dim + 2 * (n_kv_heads * head_dim)
+
+    // Phi3-specific fields for FFN gate/up processing
+    public FloatTensor hbG; // Gate states buffer
+    public FloatTensor hbU; // Up states buffer
+
     public Phi3State(Configuration config, int batchsize) {
         super(config, batchsize);
+
+        // Initialize Phi3-specific fields
+        Phi3Configuration phi3Config = (Phi3Configuration) config;
+
+        // QKV buffer size: op_size = num_heads * head_dim + 2 * (num_key_value_heads * head_dim)
+        int opSize = phi3Config.dim() + 2 * (phi3Config.numberOfKeyValueHeads() * phi3Config.headSize());
+        this.qkv = ArrayFloatTensor.allocate(opSize);
+
+        // FFN gate and up state buffers
+        this.hbG = ArrayFloatTensor.allocate(phi3Config.hiddenDim());
+        this.hbU = ArrayFloatTensor.allocate(phi3Config.hiddenDim());
     }
 
     @Override
     protected StateFields createStateFields(Configuration config) {
-        return null;
+        StateFields fields = new StateFields();
+
+        Phi3Configuration phi3Config = (Phi3Configuration) config;
+
+        // Phi3-specific dimensions
+        int dim = phi3Config.dim();
+        int headSize = phi3Config.headSize();
+        int nHeads = phi3Config.numberOfHeads();
+        int nKvHeads = phi3Config.numberOfKeyValueHeads();
+        int kvDim = (dim * nKvHeads) / nHeads;
+        int hiddenDim = phi3Config.hiddenDim();
+        int contextLength = phi3Config.contextLength();
+        int vocabSize = phi3Config.vocabularySize();
+        int nLayers = phi3Config.numberOfLayers();
+
+        // Standard tensor allocations for Phi3
+        fields.x = ArrayFloatTensor.allocate(dim);
+        fields.xb = ArrayFloatTensor.allocate(dim); // Used for attention output
+        fields.xb2 = ArrayFloatTensor.allocate(dim); // Used for residual connections
+        fields.hb = ArrayFloatTensor.allocate(2 * hiddenDim); // Combined gate/up buffer
+        fields.hb2 = ArrayFloatTensor.allocate(hiddenDim); // FFN output buffer
+
+        // Attention-related tensors
+        fields.q = ArrayFloatTensor.allocate(dim); // Query states
+        fields.k = ArrayFloatTensor.allocate(kvDim); // Key states
+        fields.v = ArrayFloatTensor.allocate(kvDim); // Value states
+        fields.att = ArrayFloatTensor.allocate(nHeads, contextLength); // Attention scores
+
+        // Output logits
+        fields.logits = ArrayFloatTensor.allocate(vocabSize);
+
+        // Key-value cache with Phi3 dimensions
+        fields.keyCache = Stream.generate(() -> ArrayFloatTensor.allocate(contextLength, kvDim)).limit(nLayers).toArray(FloatTensor[]::new);
+        fields.valueCache = Stream.generate(() -> ArrayFloatTensor.allocate(contextLength, kvDim)).limit(nLayers).toArray(FloatTensor[]::new);
+
+        // TornadoVM wrapper arrays for GPU acceleration
+        fields.wrapX = new FloatArray(dim);
+        fields.wrapXb = new FloatArray(dim);
+        fields.wrapXb2 = new FloatArray(dim);
+        fields.wrapHb = new FloatArray(2 * hiddenDim);
+        fields.wrapHb2 = new FloatArray(hiddenDim);
+        fields.wrapLogits = new FloatArray(vocabSize);
+        fields.wrapQ = new FloatArray(dim);
+        fields.wrapK = new FloatArray(kvDim);
+        fields.wrapV = new FloatArray(kvDim);
+
+        // KV cache wrappers
+        fields.wrapKeyCache = new FloatArray(contextLength * kvDim * nLayers);
+        fields.wrapValueCache = new FloatArray(contextLength * kvDim * nLayers);
+        fields.wrapKeyCache.init(0.f);
+        fields.wrapValueCache.init(0.f);
+
+        // Attention wrapper
+        fields.wrapAtt = new FloatArray(nHeads * contextLength);
+
+        // Position holder for GPU operations
+        fields.positionHolder = new IntArray(1);
+
+        // Temporary arrays for reductions and operations
+        fields.temp = new FloatArray(1 + ((dim + localSize - 1) / localSize));
+        fields.tempFFN = new FloatArray(1 + ((hiddenDim + localSize - 1) / localSize));
+        fields.tempLogits = new FloatArray(1 + ((vocabSize + localSize - 1) / localSize));
+
+        return fields;
     }
 }

--- a/src/main/java/com/example/inference/state/Phi3State.java
+++ b/src/main/java/com/example/inference/state/Phi3State.java
@@ -17,6 +17,10 @@ public class Phi3State extends State {
     public FloatTensor hbG; // Gate states buffer
     public FloatTensor hbU; // Up states buffer
 
+    public FloatArray wrapQkv; // TornadoVM wrapper for QKV buffer
+    public FloatArray wrapHbG; // TornadoVM wrapper for gate states
+    public FloatArray wrapHbU; // TornadoVM wrapper for up states
+
     public Phi3State(Configuration config, int batchsize) {
         super(config, batchsize);
 
@@ -30,6 +34,11 @@ public class Phi3State extends State {
         // FFN gate and up state buffers
         this.hbG = ArrayFloatTensor.allocate(phi3Config.hiddenDim());
         this.hbU = ArrayFloatTensor.allocate(phi3Config.hiddenDim());
+
+        // TornadoVM wrappers for GPU acceleration
+        this.wrapQkv = new FloatArray(opSize);
+        this.wrapHbG = new FloatArray(phi3Config.hiddenDim());
+        this.wrapHbU = new FloatArray(phi3Config.hiddenDim());
     }
 
     @Override

--- a/src/main/java/com/example/inference/weights/standard/Phi3StandardWeights.java
+++ b/src/main/java/com/example/inference/weights/standard/Phi3StandardWeights.java
@@ -1,0 +1,52 @@
+package com.example.inference.weights.standard;
+
+import com.example.core.model.GGMLType;
+import com.example.core.model.tensor.FloatTensor;
+import com.example.inference.weights.standard.StandardWeights;
+
+public class Phi3StandardWeights extends StandardWeights {
+
+    // Phi3-specific weight fields that don't exist in the base StandardWeights
+    public final FloatTensor[] wqkv; // Combined query, key, value matrices (Phi3 format)
+    public final FloatTensor[] wDown; // FFN down projection weight matrices
+    public final FloatTensor[] wGateUp; // FFN gate and up projection weight matrices (combined)
+
+    /**
+     * Constructor for Phi3 standard (non-TornadoVM) mode
+     * Maps Phi3-specific weights to the standard format and stores Phi3-specific weights
+     *
+     * @param token_embedding_table Token embeddings matrix
+     * @param rms_att_weight        RMSNorm weights for attention layers
+     * @param wqkv                  Combined query, key, value weight matrices (Phi3 format)
+     * @param wo                    Output projection matrices
+     * @param rms_ffn_weight        RMSNorm weights for FFN layers
+     * @param wDown                 FFN down projection weight matrices
+     * @param wGateUp               FFN gate and up projection weight matrices (combined)
+     * @param rms_final_weight      Final layer normalization weights
+     * @param freq_cis_real         RoPE cosine components
+     * @param freq_cis_imag         RoPE sine components
+     * @param wcls                  Classifier weights for output logits
+     * @param weightType            Weight type specification
+     */
+    public Phi3StandardWeights(FloatTensor token_embedding_table,
+            FloatTensor[] rms_att_weight, FloatTensor[] wqkv, FloatTensor[] wo, FloatTensor[] rms_ffn_weight, FloatTensor[] wDown,
+            FloatTensor[] wGateUp, FloatTensor rms_final_weight, FloatTensor freq_cis_real, FloatTensor freq_cis_imag, FloatTensor wcls, GGMLType weightType) {
+
+        // Call parent constructor with standard format (using nulls for unsupported weights)
+        super(token_embedding_table, rms_att_weight,
+                null, null, null, // wq, wk, wv - not used in Phi3
+                wo, rms_ffn_weight,
+                null, null, null, // w1, w2, w3 - not used in Phi3
+                rms_final_weight, freq_cis_real, freq_cis_imag, wcls, weightType);
+
+        // Store Phi3-specific weights
+        this.wqkv = wqkv;
+        this.wDown = wDown;
+        this.wGateUp = wGateUp;
+    }
+
+    @Override
+    public GGMLType getWeightType() {
+        return weightType;
+    }
+}

--- a/src/main/java/com/example/inference/weights/tornado/Phi3TornadoWeights.java
+++ b/src/main/java/com/example/inference/weights/tornado/Phi3TornadoWeights.java
@@ -1,0 +1,52 @@
+package com.example.inference.weights.tornado;
+
+import com.example.core.model.GGMLType;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+
+public class Phi3TornadoWeights extends TornadoWeights {
+
+    // Phi3-specific weight arrays
+    public HalfFloatArray[] wqkvLayered;    // Combined QKV weights: (layer, op_size, dim) where op_size = dim + 2 * (n_kv_heads * head_dim)
+    public HalfFloatArray[] wDownLayered;   // FFN down projection: (layer, dim, hidden_dim)
+    public HalfFloatArray[] wUpLayered;     // FFN up projection: (layer, hidden_dim, dim)
+
+    // @formatter:off
+    public Phi3TornadoWeights(
+            FloatArray tokenEmbeddingTable,
+            FloatArray[] rms_att_weightLayered,
+            HalfFloatArray[] wqkvLayered,        // Combined QKV weights for Phi3
+            HalfFloatArray[] woLayered,
+            FloatArray[] rms_ffn_weightLayered,
+            HalfFloatArray[] wDownLayered,       // FFN down weights
+            HalfFloatArray[] wUpLayered,         // FFN up weights
+            FloatArray rms_final_weight_as_floatArray,
+            FloatArray freq_cis_realFlat,
+            FloatArray freq_cis_imagFlat,
+            HalfFloatArray wclsByteArray,
+            GGMLType weightType) {
+
+        // Call to TornadoWeights constructor with null values for unused standard weights
+        super(tokenEmbeddingTable,
+                rms_att_weightLayered,
+                null,  // wqLayered - not used in Phi3, using combined wqkv instead
+                null,  // wkLayered - not used in Phi3, using combined wqkv instead
+                null,  // wvLayered - not used in Phi3, using combined wqkv instead
+                woLayered,
+                rms_ffn_weightLayered,
+                null,  // w1Layered - not used in Phi3, using wUp instead
+                null,  // w2Layered - not used in Phi3, using wDown instead
+                null,  // w3Layered - not used in Phi3, using wUp instead
+                rms_final_weight_as_floatArray,
+                freq_cis_realFlat,
+                freq_cis_imagFlat,
+                wclsByteArray,
+                weightType);
+
+        // Initialize Phi3-specific fields
+        this.wqkvLayered = wqkvLayered;
+        this.wDownLayered = wDownLayered;
+        this.wUpLayered = wUpLayered;
+    }
+    // @formatter:on
+}

--- a/src/main/java/com/example/model/Model.java
+++ b/src/main/java/com/example/model/Model.java
@@ -68,7 +68,7 @@ public interface Model {
         ChatFormat chatFormat = chatFormat();
         TornadoVMMasterPlan tornadoVMPlan = null;
 
-        if (!getModelType().equals(ModelType.QWEN_3)) {
+        if (!getModelType().equals(ModelType.QWEN_3) && !getModelType().equals(ModelType.PHI_3)) {
             conversationTokens.add(chatFormat.getBeginOfText());
         }
 

--- a/src/main/java/com/example/model/Model.java
+++ b/src/main/java/com/example/model/Model.java
@@ -164,7 +164,7 @@ public interface Model {
 
         List<Integer> promptTokens = new ArrayList<>();
 
-        if (!getModelType().equals(ModelType.QWEN_3)) {
+        if (!getModelType().equals(ModelType.QWEN_3) && !getModelType().equals(ModelType.PHI_3)) {
             promptTokens.add(chatFormat.getBeginOfText());
         }
 

--- a/src/main/java/com/example/model/ModelType.java
+++ b/src/main/java/com/example/model/ModelType.java
@@ -9,14 +9,13 @@ import com.example.model.loader.Qwen3ModelLoader;
 import java.nio.channels.FileChannel;
 
 /**
- * Enumerates the different types of models supported by GPULlama3.java.
- * This enum helps in categorizing and handling model-specific logic
- * based on the type of model being used.
+ * Enumerates the different types of models supported by GPULlama3.java. This enum helps in categorizing and handling model-specific
+ * logic based on the type of model being used.
  *
  * <p><b>Usage:</b> Use {@code ModelType} to specify or retrieve the type of
- * large language model (LLM), such as Llama or Qwen3. This ensures clean and
- * structured handling of model behaviors and configurations by dispatching
- * calls to the appropriate model loader for each specific model type.</p>
+ * large language model (LLM), such as Llama or Qwen3. This ensures clean and structured handling of model behaviors and configurations by
+ * dispatching calls to the appropriate model loader for each
+ *  model type.</p>
  *
  * <p>Each enum value represents a distinct model type, which might be used for
  * conditional logic, initialization, or resource allocation within GPULlama3.java.</p>

--- a/src/main/java/com/example/model/ModelType.java
+++ b/src/main/java/com/example/model/ModelType.java
@@ -3,6 +3,7 @@ package com.example.model;
 import com.example.core.model.GGUF;
 import com.example.model.loader.LlamaModelLoader;
 import com.example.model.loader.MistralModelLoader;
+import com.example.model.loader.Phi3ModelLoader;
 import com.example.model.loader.Qwen3ModelLoader;
 
 import java.nio.channels.FileChannel;
@@ -39,6 +40,13 @@ public enum ModelType {
         @Override
         public Model loadModel(FileChannel fileChannel, GGUF gguf, int contextLength, boolean loadWeights) {
             return new Qwen3ModelLoader(fileChannel, gguf, contextLength, loadWeights).loadModel();
+        }
+    },
+
+    PHI_3 {
+        @Override
+        public Model loadModel(FileChannel fileChannel, GGUF gguf, int contextLength, boolean loadWeights) {
+            return new Phi3ModelLoader(fileChannel, gguf, contextLength, loadWeights).loadModel();
         }
     },
 

--- a/src/main/java/com/example/model/format/ChatFormat.java
+++ b/src/main/java/com/example/model/format/ChatFormat.java
@@ -1,9 +1,13 @@
 package com.example.model.format;
 
+import com.example.model.phi3.Phi3;
 import com.example.tokenizer.impl.LlamaTokenizer;
 import com.example.tokenizer.impl.MistralTokenizer;
+import com.example.tokenizer.impl.Phi3Tokenizer;
 import com.example.tokenizer.impl.Qwen3Tokenizer;
+import com.example.tokenizer.impl.Tokenizer;
 
+import javax.management.relation.Role;
 import java.util.List;
 import java.util.Set;
 
@@ -17,15 +21,13 @@ public interface ChatFormat {
     }
 
     static ChatFormat create(Object tokenizer, ChatTokens chatTokens) {
-        if (tokenizer instanceof LlamaTokenizer llamaTokenizer) {
-            return new LlamaChatFormat(llamaTokenizer);
-        } else if (tokenizer instanceof MistralTokenizer mistralTokenizer) {
-            return new MistralChatFormat(mistralTokenizer);
-        } else if (tokenizer instanceof Qwen3Tokenizer qwen3Tokenizer) {
-            return new Qwen3ChatFormat(qwen3Tokenizer, chatTokens);
-        } else {
-            throw new IllegalArgumentException("Unsupported tokenizer type: " + tokenizer.getClass().getName());
-        }
+        return switch (tokenizer) {
+            case LlamaTokenizer llamaTokenizer -> new LlamaChatFormat(llamaTokenizer);
+            case MistralTokenizer mistralTokenizer -> new MistralChatFormat(mistralTokenizer);
+            case Qwen3Tokenizer qwen3Tokenizer -> new Qwen3ChatFormat(qwen3Tokenizer, chatTokens);
+            case Phi3Tokenizer phi3Tokenizer -> new Phi3ChatFormat(phi3Tokenizer, chatTokens);
+            default -> throw new IllegalArgumentException("Unsupported tokenizer type: " + tokenizer.getClass().getName());
+        };
     }
 
     List<Integer> encodeHeader(Message message);

--- a/src/main/java/com/example/model/format/ChatFormat.java
+++ b/src/main/java/com/example/model/format/ChatFormat.java
@@ -1,24 +1,14 @@
 package com.example.model.format;
 
-import com.example.model.phi3.Phi3;
 import com.example.tokenizer.impl.LlamaTokenizer;
 import com.example.tokenizer.impl.MistralTokenizer;
 import com.example.tokenizer.impl.Phi3Tokenizer;
 import com.example.tokenizer.impl.Qwen3Tokenizer;
-import com.example.tokenizer.impl.Tokenizer;
 
-import javax.management.relation.Role;
 import java.util.List;
 import java.util.Set;
 
 public interface ChatFormat {
-
-    default ChatTokens chatTokens() {
-        throw new UnsupportedOperationException("ChatFormat for Llama and Mistral does not support chatTokens");
-    }
-
-    record ChatTokens(String tStartHeader, String tEndHeader, String tEndOfTurn, String tEndOfText, String tEndOfTextFim) {
-    }
 
     static ChatFormat create(Object tokenizer, ChatTokens chatTokens) {
         return switch (tokenizer) {
@@ -30,6 +20,10 @@ public interface ChatFormat {
         };
     }
 
+    default ChatTokens chatTokens() {
+        throw new UnsupportedOperationException("ChatFormat for Llama and Mistral does not support chatTokens");
+    }
+
     List<Integer> encodeHeader(Message message);
 
     List<Integer> encodeMessage(Message message);
@@ -38,14 +32,18 @@ public interface ChatFormat {
 
     Set<Integer> getStopTokens();
 
+    record ChatTokens(String tStartHeader, String tEndHeader, String tEndOfTurn, String tEndOfText, String tEndOfTextFim) {
+    }
+
     /**
      * Represents a single message in a LLM chat session.
      *
-     * Each message is associated with a specific role (system, user, or assistant)
-     * and contains the textual content of that message.
+     * Each message is associated with a specific role (system, user, or assistant) and contains the textual content of that message.
      *
-     * @param role the participant who issued the message (SYSTEM, USER, or ASSISTANT).
-     * @param content the textual content of the message
+     * @param role
+     *         the participant who issued the message (SYSTEM, USER, or ASSISTANT).
+     * @param content
+     *         the textual content of the message
      */
     record Message(Role role, String content) {
     }
@@ -60,7 +58,8 @@ public interface ChatFormat {
      * <li><strong>ASSISTANT</strong> - represents output from the AI assistant.</li>
      * </ul>
      *
-     * @param name the string representation of the role
+     * @param name
+     *         the string representation of the role
      */
     record Role(String name) {
         public static Role SYSTEM = new Role("system");

--- a/src/main/java/com/example/model/format/ChatFormat.java
+++ b/src/main/java/com/example/model/format/ChatFormat.java
@@ -13,7 +13,7 @@ public interface ChatFormat {
         throw new UnsupportedOperationException("ChatFormat for Llama and Mistral does not support chatTokens");
     }
 
-    public record ChatTokens(String tStartHeader, String tEndHeader, String tEndOfTurn, String tEndOfText, String tEndOfTextFim) {
+    record ChatTokens(String tStartHeader, String tEndHeader, String tEndOfTurn, String tEndOfText, String tEndOfTextFim) {
     }
 
     static ChatFormat create(Object tokenizer, ChatTokens chatTokens) {

--- a/src/main/java/com/example/model/format/Phi3ChatFormat.java
+++ b/src/main/java/com/example/model/format/Phi3ChatFormat.java
@@ -1,8 +1,6 @@
 package com.example.model.format;
 
-import com.example.tokenizer.impl.Phi3Tokenizer;
 import com.example.tokenizer.impl.Tokenizer;
-import org.apache.logging.log4j.message.Message;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,9 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Chat format implementation specifically designed for the Phi3 model.
- * This class handles the specific prompt formatting and token management
- * required for Phi3's conversational interface.
+ * Chat format implementation specifically designed for the Phi3 model. This class handles the specific prompt formatting and token management required for Phi3's conversational interface.
  *
  * <p>Phi3 uses a simpler chat format compared to other models:
  * <ul>
@@ -25,8 +21,6 @@ import java.util.Set;
 public class Phi3ChatFormat implements ChatFormat {
 
     protected final Tokenizer tokenizer;
-    protected ChatTokens chatTokens;
-
     protected final int beginOfText;
     protected final int startHeader;
     protected final int endHeader;
@@ -35,16 +29,16 @@ public class Phi3ChatFormat implements ChatFormat {
     protected final int endOfMessage;
     protected final int endOfTextFim;
     protected final int end; // End token for the chat format
+    protected ChatTokens chatTokens;
 
     public Phi3ChatFormat(Tokenizer tokenizer, ChatTokens chatTokens) {
-//        super(tokenizer, "", "", "<|end|>", "", "", "", "");
         this.tokenizer = tokenizer;
         this.chatTokens = chatTokens;
         this.beginOfText = tokenizer.getSpecialTokens().getOrDefault("", -1);
         this.startHeader = tokenizer.getSpecialTokens().getOrDefault("", -1);
         this.endHeader = tokenizer.getSpecialTokens().getOrDefault("<|end|>", -1);
         this.endOfTurn = tokenizer.getSpecialTokens().getOrDefault("", -1);
-        this.endOfText = tokenizer.getSpecialTokens().getOrDefault("",-1);
+        this.endOfText = tokenizer.getSpecialTokens().getOrDefault("", -1);
         this.endOfTextFim = tokenizer.getSpecialTokens().getOrDefault("", -1);
         this.endOfMessage = tokenizer.getSpecialTokens().getOrDefault("", -1);
         // Initialize end token
@@ -73,7 +67,6 @@ public class Phi3ChatFormat implements ChatFormat {
         } else {
             tokens.addAll(this.tokenizer.encodeAsList(tokenRole));
         }
-        //tokens.addAll(this.tokenizer.encodeAsList("\n"));
         return tokens;
     }
 
@@ -91,7 +84,6 @@ public class Phi3ChatFormat implements ChatFormat {
 
     public List<Integer> encodeDialogPrompt(boolean appendAssistantTurn, List<Message> dialog) {
         List<Integer> tokens = new ArrayList<>();
-        //tokens.add(beginOfText);
         for (Message message : dialog) {
             tokens.addAll(this.encodeMessage(message));
         }

--- a/src/main/java/com/example/model/format/Phi3ChatFormat.java
+++ b/src/main/java/com/example/model/format/Phi3ChatFormat.java
@@ -1,0 +1,105 @@
+package com.example.model.format;
+
+import com.example.tokenizer.impl.Phi3Tokenizer;
+import com.example.tokenizer.impl.Tokenizer;
+import org.apache.logging.log4j.message.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Chat format implementation specifically designed for the Phi3 model.
+ * This class handles the specific prompt formatting and token management
+ * required for Phi3's conversational interface.
+ *
+ * <p>Phi3 uses a simpler chat format compared to other models:
+ * <ul>
+ *   <li>Role tokens: {@code <|system|>}, {@code <|user|>}, {@code <|assistant|>}</li>
+ *   <li>End token: {@code <|end|>}</li>
+ *   <li>No separate begin-of-text or header/content separation</li>
+ * </ul>
+ * </p>
+ */
+public class Phi3ChatFormat implements ChatFormat {
+
+    protected final Tokenizer tokenizer;
+    protected ChatTokens chatTokens;
+
+    protected final int beginOfText;
+    protected final int startHeader;
+    protected final int endHeader;
+    protected final int endOfTurn;
+    protected final int endOfText;
+    protected final int endOfMessage;
+    protected final int endOfTextFim;
+    protected final int end; // End token for the chat format
+
+    public Phi3ChatFormat(Tokenizer tokenizer, ChatTokens chatTokens) {
+//        super(tokenizer, "", "", "<|end|>", "", "", "", "");
+        this.tokenizer = tokenizer;
+        this.chatTokens = chatTokens;
+        this.beginOfText = tokenizer.getSpecialTokens().getOrDefault("", -1);
+        this.startHeader = tokenizer.getSpecialTokens().getOrDefault("", -1);
+        this.endHeader = tokenizer.getSpecialTokens().getOrDefault("<|end|>", -1);
+        this.endOfTurn = tokenizer.getSpecialTokens().getOrDefault("", -1);
+        this.endOfText = tokenizer.getSpecialTokens().getOrDefault("",-1);
+        this.endOfTextFim = tokenizer.getSpecialTokens().getOrDefault("", -1);
+        this.endOfMessage = tokenizer.getSpecialTokens().getOrDefault("", -1);
+        // Initialize end token
+        Map<String, Integer> specialTokens = this.tokenizer.getSpecialTokens();
+        this.end = specialTokens.get("<|end|>");
+    }
+
+    public ChatTokens chatTokens() {
+        return chatTokens;
+    }
+
+    public Tokenizer getTokenizer() {
+        return tokenizer;
+    }
+
+    public Set<Integer> getStopTokens() {
+        return Set.of(end);
+    }
+
+    public List<Integer> encodeHeader(Message message) {
+        List<Integer> tokens = new ArrayList<>();
+        String tokenRole = "<|" + message.role().name() + "|>";
+        final Integer idxSpecial = tokenizer.getSpecialTokens().get(tokenRole);
+        if (idxSpecial != null) {
+            tokens.add(idxSpecial);
+        } else {
+            tokens.addAll(this.tokenizer.encodeAsList(tokenRole));
+        }
+        //tokens.addAll(this.tokenizer.encodeAsList("\n"));
+        return tokens;
+    }
+
+    public List<Integer> encodeMessage(Message message) {
+        List<Integer> tokens = this.encodeHeader(message);
+        tokens.addAll(this.tokenizer.encodeAsList(message.content().strip()));
+        tokens.add(tokenizer.getSpecialTokens().get("<|end|>"));
+        return tokens;
+    }
+
+    @Override
+    public int getBeginOfText() {
+        throw new UnsupportedOperationException("Phi3 does not use a begin-of-text token.");
+    }
+
+    public List<Integer> encodeDialogPrompt(boolean appendAssistantTurn, List<Message> dialog) {
+        List<Integer> tokens = new ArrayList<>();
+        //tokens.add(beginOfText);
+        for (Message message : dialog) {
+            tokens.addAll(this.encodeMessage(message));
+        }
+        if (appendAssistantTurn) {
+            // Add the start of an assistant message for the model to complete.
+            tokens.addAll(this.encodeHeader(new Message(Role.ASSISTANT, "")));
+        }
+        return tokens;
+    }
+}
+

--- a/src/main/java/com/example/model/format/Qwen3ChatFormat.java
+++ b/src/main/java/com/example/model/format/Qwen3ChatFormat.java
@@ -12,9 +12,6 @@ import java.util.Set;
  */
 public class Qwen3ChatFormat implements ChatFormat {
 
-    protected Qwen3Tokenizer tokenizer;
-    protected ChatTokens chatTokens;
-
     protected final int beginOfText;
     protected final int startHeader;
     protected final int endHeader;
@@ -22,13 +19,13 @@ public class Qwen3ChatFormat implements ChatFormat {
     protected final int endOfText;
     protected final int endOfMessage;
     protected final int endOfTextFim;
-
     protected final int imStart; // beginOfText
     protected final int imEnd; // endOfText
-
     protected final int fimPrefix;
     protected final int fimSuffix;
     protected final int fimMiddle;
+    protected Qwen3Tokenizer tokenizer;
+    protected ChatTokens chatTokens;
 
     public Qwen3ChatFormat(Qwen3Tokenizer tokenizer, ChatTokens chatTokens) {
         this.tokenizer = tokenizer;
@@ -106,15 +103,12 @@ public class Qwen3ChatFormat implements ChatFormat {
         return beginOfText;
     }
 
-
-
     @Override
     public Set<Integer> getStopTokens() {
         if (imEnd == -1 && endOfText == -1) {
             throw new IllegalStateException("No stop token is defined.");
         }
         if (imEnd == -1) {
-
             return Set.of(endOfText);
         }
         return Set.of(imEnd, endOfText, endOfTextFim);

--- a/src/main/java/com/example/model/format/Qwen3ChatFormat.java
+++ b/src/main/java/com/example/model/format/Qwen3ChatFormat.java
@@ -106,6 +106,8 @@ public class Qwen3ChatFormat implements ChatFormat {
         return beginOfText;
     }
 
+
+
     @Override
     public Set<Integer> getStopTokens() {
         if (imEnd == -1 && endOfText == -1) {

--- a/src/main/java/com/example/model/llama/LlamaConfiguration.java
+++ b/src/main/java/com/example/model/llama/LlamaConfiguration.java
@@ -2,8 +2,16 @@ package com.example.model.llama;
 
 import com.example.model.Configuration;
 
-public record LlamaConfiguration(int dim, int hiddenDim, int numberOfLayers, int numberOfHeads, int numberOfKeyValueHeads, int vocabularySize, int contextLength, float rmsNormEps, float ropeTheta)
-        implements Configuration {
+// @formatter:off
+public record LlamaConfiguration(int dim,
+                                 int hiddenDim,
+                                 int numberOfLayers,
+                                 int numberOfHeads,
+                                 int numberOfKeyValueHeads,
+                                 int vocabularySize,
+                                 int contextLength,
+                                 float rmsNormEps,
+                                 float ropeTheta) implements Configuration {
 
     @Override
     public int numberOfHeadsKey() {

--- a/src/main/java/com/example/model/loader/ModelLoader.java
+++ b/src/main/java/com/example/model/loader/ModelLoader.java
@@ -11,14 +11,13 @@ import com.example.core.model.tensor.GGMLTensorEntry;
 import com.example.core.model.tensor.Q4_0FloatTensor;
 import com.example.core.model.tensor.Q8_0FloatTensor;
 import com.example.core.types.Pair;
+import com.example.inference.operation.RoPE;
+import com.example.inference.weights.Weights;
 import com.example.inference.weights.standard.LlamaStandardWeights;
 import com.example.inference.weights.tornado.LlamaTornadoWeights;
-import com.example.inference.weights.tornado.TornadoWeights;
-import com.example.inference.weights.Weights;
 import com.example.model.Configuration;
 import com.example.model.Model;
 import com.example.model.ModelType;
-import com.example.inference.operation.RoPE;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
@@ -63,30 +62,14 @@ public abstract class ModelLoader {
                 return ModelType.LLAMA_3;
             } else if (lowerName.contains("qwen3")) {
                 return ModelType.QWEN_3;
-            }else if (lowerName.contains("phi3")) {
+            } else if (lowerName.contains("phi3")) {
                 return ModelType.PHI_3;
-        }
+            }
 
-//        // Check by tokenizer model
-//        if (TOKENIZER_MISTRAL_MODEL.equals(tokenizerModel)) {
-//            return ModelType.MISTRAL;
-//        } else if (TOKENIZER_LLAMA_3_MODEL.equals(tokenizerModel)) {
-//            return ModelType.LLAMA_3;
-//        }
-
-//        // Check by vocabulary size as fallback
-//        if (vocabSize != null) {
-//            if (vocabSize == 32768) {
-//                return ModelType.MISTRAL;
-//            } else if (vocabSize == 128256) {
-//                return ModelType.LLAMA_3;
-//            }
         }
 
         return ModelType.UNKNOWN;
     }
-
-    public abstract Model loadModel();
 
     public static Model loadModel(Path ggufPath, int contextLength, boolean loadWeights) throws IOException {
         // initial load of metadata from gguf file
@@ -97,80 +80,6 @@ public abstract class ModelLoader {
         // model type-specific load
         return modelType.loadModel(fileChannel, gguf, contextLength, loadWeights);
     }
-
-    //@formatter:off
-    public Weights loadWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config) {
-        boolean ropeScaling = tensorEntries.containsKey("rope_freqs");
-        RopeConfig ropeConfig = new RopeConfig(8.0f,         // scaleFactor
-                1.0f,                    // loFreqFactor
-                3.0f,                    // hiFreqFactor
-                8192                     // oldContextLength
-        );
-
-        Pair<float[], float[]> ropeFreqs = RoPE.precomputeFreqsCis(
-                config.contextLength(),         // Maximum sequence length the model can process
-                config.headSize(),              // Dimension of each attention head
-                config.ropeTheta(),             // Base frequency parameter (typically 10000.0)
-                ropeScaling,                    // Whether to apply frequency scaling (determined by model type)
-                ropeConfig.scaleFactor,         // Scale factor for extending context length (NTK-aware scaling)
-                ropeConfig.loFreqFactor,        // Low frequency scaling factor for better long-range dependencies
-                ropeConfig.hiFreqFactor,        // High frequency scaling factor for preserving local precision
-                ropeConfig.oldContextLength     // Original context length the model was trained with
-        );
-
-        GGMLTensorEntry tokenEmbeddings = tensorEntries.get("token_embd.weight");
-        GGMLTensorEntry outputWeight = tensorEntries.getOrDefault("output.weight", tokenEmbeddings);
-
-        if (LlamaApp.USE_TORNADOVM) {
-            System.out.println("Loading model weights in TornadoVM format (loading " + outputWeight.ggmlType() + " -> " + GGMLType.F16 + ")");
-            return createTornadoVMWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
-        } else {
-            return createStandardWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
-        }
-    }
-    //@formatter:on
-
-    public Weights createTornadoVMWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config, Pair<float[], float[]> ropeFreqs, GGMLTensorEntry tokenEmbeddings,
-            GGMLTensorEntry outputWeight) {
-        return new LlamaTornadoWeights(
-                // Load directly to TornadoVM format
-                loadTensorAsFloatArray(tokenEmbeddings), loadArrayAsFloatArrayFromBuffer(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_norm.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_q.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_k.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_v.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_output.weight")),
-                loadArrayAsFloatArrayFromBuffer(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_norm.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_gate.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_down.weight")),
-                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_up.weight")), floatBufferToFloatArray(tensorEntries.get("output_norm.weight")),
-                FloatArray.fromArray(ropeFreqs.first()), FloatArray.fromArray(ropeFreqs.second()), loadTensorAsHalfFloatArray(outputWeight), outputWeight.ggmlType()) {
-        };
-    }
-
-    //@formatter:off
-    /**
-     * Creates weights in standard format only
-     */
-    public Weights createStandardWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config, Pair<float[], float[]> ropeFreqs, GGMLTensorEntry tokenEmbeddings,
-            GGMLTensorEntry outputWeight) {
-        return new LlamaStandardWeights(
-                loadQuantized(tokenEmbeddings),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_norm.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_q.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_k.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_v.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_output.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_norm.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_gate.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_down.weight")),
-                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_up.weight")),
-                loadQuantized(tensorEntries.get("output_norm.weight")),
-                new ArrayFloatTensor(ropeFreqs.first()),
-                new ArrayFloatTensor(ropeFreqs.second()),
-                loadQuantized(outputWeight),
-                outputWeight.ggmlType());
-    }
-    //@formatter:on
 
     public static FloatTensor loadQuantized(GGMLTensorEntry entry) {
         GGMLType ggmlType = entry.ggmlType();
@@ -190,6 +99,7 @@ public abstract class ModelLoader {
         }
         return array;
     }
+    //@formatter:on
 
     public static HalfFloatArray[] loadArrayAsHalfFloatArray(int size, IntFunction<GGMLTensorEntry> getTensorEntry) {
         HalfFloatArray[] array = new HalfFloatArray[size];
@@ -199,6 +109,8 @@ public abstract class ModelLoader {
         return array;
     }
 
+    //@formatter:off
+
     public static FloatArray floatBufferToFloatArray(GGMLTensorEntry tensorEntry) {
         if (tensorEntry.ggmlType() == GGMLType.F32) {
             FloatBuffer buffer = tensorEntry.memorySegment().asByteBuffer().order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
@@ -207,6 +119,7 @@ public abstract class ModelLoader {
             throw new UnsupportedOperationException("Conversion to FloatArray from " + tensorEntry.ggmlType());
         }
     }
+    //@formatter:on
 
     public static FloatArray[] loadArrayAsFloatArrayFromBuffer(int size, IntFunction<GGMLTensorEntry> getTensorEntry) {
         FloatArray[] array = new FloatArray[size];
@@ -279,6 +192,79 @@ public abstract class ModelLoader {
             case F32 -> tensorEntry.memorySegment().asByteBuffer().order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer();
             default -> throw new UnsupportedOperationException("Conversion to " + ggmlType);
         };
+    }
+
+    public abstract Model loadModel();
+
+    //@formatter:off
+    public Weights loadWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config) {
+        boolean ropeScaling = tensorEntries.containsKey("rope_freqs");
+        RopeConfig ropeConfig = new RopeConfig(8.0f,         // scaleFactor
+                1.0f,                    // loFreqFactor
+                3.0f,                    // hiFreqFactor
+                8192                     // oldContextLength
+        );
+
+        Pair<float[], float[]> ropeFreqs = RoPE.precomputeFreqsCis(
+                config.contextLength(),         // Maximum sequence length the model can process
+                config.headSize(),              // Dimension of each attention head
+                config.ropeTheta(),             // Base frequency parameter (typically 10000.0)
+                ropeScaling,                    // Whether to apply frequency scaling (determined by model type)
+                ropeConfig.scaleFactor,         // Scale factor for extending context length (NTK-aware scaling)
+                ropeConfig.loFreqFactor,        // Low frequency scaling factor for better long-range dependencies
+                ropeConfig.hiFreqFactor,        // High frequency scaling factor for preserving local precision
+                ropeConfig.oldContextLength     // Original context length the model was trained with
+        );
+
+        GGMLTensorEntry tokenEmbeddings = tensorEntries.get("token_embd.weight");
+        GGMLTensorEntry outputWeight = tensorEntries.getOrDefault("output.weight", tokenEmbeddings);
+
+        if (LlamaApp.USE_TORNADOVM) {
+            System.out.println("Loading model weights in TornadoVM format (loading " + outputWeight.ggmlType() + " -> " + GGMLType.F16 + ")");
+            return createTornadoVMWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
+        } else {
+            return createStandardWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
+        }
+    }
+
+    public Weights createTornadoVMWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config, Pair<float[], float[]> ropeFreqs, GGMLTensorEntry tokenEmbeddings,
+            GGMLTensorEntry outputWeight) {
+        return new LlamaTornadoWeights(
+                // Load directly to TornadoVM format
+                loadTensorAsFloatArray(tokenEmbeddings), loadArrayAsFloatArrayFromBuffer(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_norm.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_q.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_k.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_v.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_output.weight")),
+                loadArrayAsFloatArrayFromBuffer(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_norm.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_gate.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_down.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_up.weight")), floatBufferToFloatArray(tensorEntries.get("output_norm.weight")),
+                FloatArray.fromArray(ropeFreqs.first()), FloatArray.fromArray(ropeFreqs.second()), loadTensorAsHalfFloatArray(outputWeight), outputWeight.ggmlType()) {
+        };
+    }
+
+    /**
+     * Creates weights in standard format only
+     */
+    public Weights createStandardWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config, Pair<float[], float[]> ropeFreqs, GGMLTensorEntry tokenEmbeddings,
+            GGMLTensorEntry outputWeight) {
+        return new LlamaStandardWeights(
+                loadQuantized(tokenEmbeddings),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_norm.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_q.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_k.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_v.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_output.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_norm.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_gate.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_down.weight")),
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_up.weight")),
+                loadQuantized(tensorEntries.get("output_norm.weight")),
+                new ArrayFloatTensor(ropeFreqs.first()),
+                new ArrayFloatTensor(ropeFreqs.second()),
+                loadQuantized(outputWeight),
+                outputWeight.ggmlType());
     }
 
     // Helper class to encapsulate RoPE configuration parameters

--- a/src/main/java/com/example/model/loader/ModelLoader.java
+++ b/src/main/java/com/example/model/loader/ModelLoader.java
@@ -63,23 +63,24 @@ public abstract class ModelLoader {
                 return ModelType.LLAMA_3;
             } else if (lowerName.contains("qwen3")) {
                 return ModelType.QWEN_3;
-            }
+            }else if (lowerName.contains("phi3")) {
+                return ModelType.PHI_3;
         }
 
-        // Check by tokenizer model
-        if (TOKENIZER_MISTRAL_MODEL.equals(tokenizerModel)) {
-            return ModelType.MISTRAL;
-        } else if (TOKENIZER_LLAMA_3_MODEL.equals(tokenizerModel)) {
-            return ModelType.LLAMA_3;
-        }
+//        // Check by tokenizer model
+//        if (TOKENIZER_MISTRAL_MODEL.equals(tokenizerModel)) {
+//            return ModelType.MISTRAL;
+//        } else if (TOKENIZER_LLAMA_3_MODEL.equals(tokenizerModel)) {
+//            return ModelType.LLAMA_3;
+//        }
 
-        // Check by vocabulary size as fallback
-        if (vocabSize != null) {
-            if (vocabSize == 32768) {
-                return ModelType.MISTRAL;
-            } else if (vocabSize == 128256) {
-                return ModelType.LLAMA_3;
-            }
+//        // Check by vocabulary size as fallback
+//        if (vocabSize != null) {
+//            if (vocabSize == 32768) {
+//                return ModelType.MISTRAL;
+//            } else if (vocabSize == 128256) {
+//                return ModelType.LLAMA_3;
+//            }
         }
 
         return ModelType.UNKNOWN;

--- a/src/main/java/com/example/model/loader/Phi3ModelLoader.java
+++ b/src/main/java/com/example/model/loader/Phi3ModelLoader.java
@@ -1,17 +1,157 @@
 package com.example.model.loader;
 
+import com.example.LlamaApp;
+import com.example.auxiliary.Timer;
+import com.example.core.model.GGMLType;
 import com.example.core.model.GGUF;
+import com.example.core.model.tensor.ArrayFloatTensor;
+import com.example.core.model.tensor.GGMLTensorEntry;
+import com.example.core.types.Pair;
+import com.example.inference.operation.RoPE;
+import com.example.inference.weights.Weights;
+import com.example.inference.weights.standard.Phi3StandardWeights;
+import com.example.inference.weights.tornado.Phi3TornadoWeights;
+import com.example.model.Configuration;
 import com.example.model.Model;
+import com.example.model.format.ChatFormat;
+import com.example.model.phi3.Phi3;
+import com.example.model.phi3.Phi3Configuration;
+import com.example.tokenizer.impl.Phi3Tokenizer;
+import com.example.tokenizer.impl.Tokenizer;
+import com.example.tokenizer.vocabulary.Vocabulary;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
+import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.util.Map;
 
 public class Phi3ModelLoader extends ModelLoader {
     public Phi3ModelLoader(FileChannel fileChannel, GGUF gguf, int contextLength, boolean loadWeights) {
         super(fileChannel, gguf, contextLength, loadWeights);
     }
 
+    // @formatter:off
     @Override
-    public Model loadModel() {
-        return null;
+    public Phi3 loadModel() {
+        try (var ignored = Timer.log("Load Phi3 model")) {
+            Map<String, Object> metadata = gguf.getMetadata();
+            final String modelPrefix = "phi3.";
+
+            Vocabulary vocabulary = Vocabulary.loadPhi3Vocabulary(metadata);
+            Tokenizer tokenizer = new Phi3Tokenizer(metadata, vocabulary);
+            System.out.println("Tokenizer: " + tokenizer.getClass().getSimpleName());
+
+            int modelContextLength = (int) metadata.get(modelPrefix + "context_length");
+            if (contextLength < 0 || modelContextLength < contextLength) {
+                contextLength = modelContextLength;
+            }
+
+            Phi3Configuration config = new Phi3Configuration(
+                    (int) metadata.get(modelPrefix + "embedding_length"),           // dim
+                    (int) metadata.get(modelPrefix + "feed_forward_length"),        // hidden_dim
+                    (int) metadata.get(modelPrefix + "block_count"),                // n_layers
+                    (int) metadata.get(modelPrefix + "attention.head_count"),       // n_heads
+
+                    metadata.containsKey(modelPrefix + "attention.head_count_kv")
+                            ? (int) metadata.get(modelPrefix + "attention.head_count_kv")
+                            : (int) metadata.get(modelPrefix + "attention.head_count"), // n_kv_heads
+
+                    vocabulary.size(),                                              // vocab_size
+                    contextLength,                                                  // context_length (user-specified, not model)
+                    (float) metadata.getOrDefault(modelPrefix + "attention.layer_norm_rms_epsilon", 1e-5f), // rms_norm_eps
+                    (float) metadata.getOrDefault(modelPrefix + "rope.freq_base", 10000f)           // rope_theta
+            );
+
+            Weights weights = null;
+            if (loadWeights) {
+                Map<String, GGMLTensorEntry> tensorEntries = GGUF.loadTensors(fileChannel, gguf.getTensorDataOffset(), gguf.getTensorInfos());
+                weights = loadWeights(tensorEntries, config, modelContextLength);
+            }
+
+            // Phi3 chat tokens
+            ChatFormat.ChatTokens chatTokens = new ChatFormat.ChatTokens(
+                    "<|system|>", "<|end|>", "<|user|>", "<|end|>", "<|assistant|>"
+            );
+
+            return new Phi3(config, tokenizer, weights, ChatFormat.create(tokenizer, chatTokens));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
+    // @formatter:on
+
+    // @formatter:off
+    private Weights loadWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config, int modelContextLength) {
+        // Calculate head size from dim and numberOfHeads
+        int headSize = config.dim() / config.numberOfHeads();
+
+        Pair<float[], float[]> ropeFreqs = RoPE.precomputeFreqsCis(
+                modelContextLength,    // Use model context length for RoPE precomputation
+                headSize,              // Calculated head size
+                config.ropeTheta(),
+                false,                 // Phi3 uses standard RoPE, not neox-style based on reference
+                8, 1, 3, 8192         // Additional RoPE parameters from reference
+        );
+
+        GGMLTensorEntry tokenEmbeddings = tensorEntries.get("token_embd.weight");
+        GGMLTensorEntry outputWeight = tensorEntries.get("output.weight"); // Phi3 always has separate output weight
+
+        if (LlamaApp.USE_TORNADOVM) {
+            System.out.println("Loading model weights in TornadoVM format (loading " + outputWeight.ggmlType() + " -> " + GGMLType.F16 + ")");
+            return createTornadoVMWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
+        } else {
+            return createStandardWeights(tensorEntries, config, ropeFreqs, tokenEmbeddings, outputWeight);
+        }
+    }
+    // @formatter:on
+
+    // @formatter:off
+    @Override
+    public Weights createTornadoVMWeights(Map<String, GGMLTensorEntry> tensorEntries, Configuration config,
+            Pair<float[], float[]> ropeFreqs, GGMLTensorEntry tokenEmbeddings,
+            GGMLTensorEntry outputWeight) {
+        return new Phi3TornadoWeights(
+                loadTensorAsFloatArray(tokenEmbeddings),
+                loadArrayAsFloatArrayFromBuffer(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_norm.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_qkv.weight")),      // Combined QKV
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_output.weight")),   // wo
+                loadArrayAsFloatArrayFromBuffer(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_norm.weight")),
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_down.weight")),      // wDown
+                loadArrayAsHalfFloatArray(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_up.weight")),        // wUp (not combined in reference)
+                floatBufferToFloatArray(tensorEntries.get("output_norm.weight")),
+                FloatArray.fromArray(ropeFreqs.first()),
+                FloatArray.fromArray(ropeFreqs.second()),
+                loadTensorAsHalfFloatArray(outputWeight),
+                outputWeight.ggmlType()
+        );
+    }
+    // @formatter:on
+
+    // @formatter:off
+    @Override
+    public Weights createStandardWeights(Map<String, GGMLTensorEntry> tensorEntries,
+            Configuration config,
+            Pair<float[], float[]> ropeFreqs,
+            GGMLTensorEntry tokenEmbeddings,
+            GGMLTensorEntry outputWeight) {
+        float[] ropeFreqsReal = ropeFreqs.first();
+        float[] ropeFreqsImag = ropeFreqs.second();
+
+        return new Phi3StandardWeights(
+                loadQuantized(tokenEmbeddings),                                                                               // token_embedding_table
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_norm.weight")),    // rms_att_weight (as FloatTensor[])
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_qkv.weight")),     // wqkv (combined)
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".attn_output.weight")),  // wo
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_norm.weight")),     // rms_ffn_weight (as FloatTensor[])
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_down.weight")),     // wDown
+                loadArrayOfQuantized(config.numberOfLayers(), i -> tensorEntries.get("blk." + i + ".ffn_up.weight")),       // wUp (separate, not combined)
+                loadQuantized(tensorEntries.get("output_norm.weight")),                                                      // rms_final_weight (as FloatTensor)
+                new ArrayFloatTensor(ropeFreqsReal),                                                                         // freq_cis_real
+                new ArrayFloatTensor(ropeFreqsImag),                                                                         // freq_cis_imag
+                loadQuantized(outputWeight),                                                                                 // wcls
+                outputWeight.ggmlType()                                                                                      // weightType
+        );
+    }
+
+    // @formatter:on
 }

--- a/src/main/java/com/example/model/loader/Phi3ModelLoader.java
+++ b/src/main/java/com/example/model/loader/Phi3ModelLoader.java
@@ -1,0 +1,17 @@
+package com.example.model.loader;
+
+import com.example.core.model.GGUF;
+import com.example.model.Model;
+
+import java.nio.channels.FileChannel;
+
+public class Phi3ModelLoader extends ModelLoader {
+    public Phi3ModelLoader(FileChannel fileChannel, GGUF gguf, int contextLength, boolean loadWeights) {
+        super(fileChannel, gguf, contextLength, loadWeights);
+    }
+
+    @Override
+    public Model loadModel() {
+        return null;
+    }
+}

--- a/src/main/java/com/example/model/mistral/MistralConfiguration.java
+++ b/src/main/java/com/example/model/mistral/MistralConfiguration.java
@@ -2,8 +2,17 @@ package com.example.model.mistral;
 
 import com.example.model.Configuration;
 
-public record MistralConfiguration(int dim, int hiddenDim, int numberOfLayers, int numberOfHeads, int numberOfKeyValueHeads, int vocabularySize, int contextLength, boolean sharedWeights,
-                                   float rmsNormEps, float ropeTheta) implements Configuration {
+// @formatter:off
+public record MistralConfiguration(int dim,
+                                   int hiddenDim,
+                                   int numberOfLayers,
+                                   int numberOfHeads,
+                                   int numberOfKeyValueHeads,
+                                   int vocabularySize,
+                                   int contextLength,
+                                   boolean sharedWeights,
+                                   float rmsNormEps,
+                                   float ropeTheta) implements Configuration {
 
     public int kvDim() {
         return dim * numberOfKeyValueHeads / numberOfHeads;

--- a/src/main/java/com/example/model/phi3/Phi3.java
+++ b/src/main/java/com/example/model/phi3/Phi3.java
@@ -4,10 +4,10 @@ import com.example.inference.InferenceCore;
 import com.example.inference.InferenceEngine;
 import com.example.inference.sampler.Sampler;
 import com.example.inference.state.Phi3State;
-import com.example.inference.state.Qwen3State;
 import com.example.inference.state.State;
 import com.example.inference.weights.Weights;
 import com.example.model.AbstractModel;
+import com.example.model.Model;
 import com.example.model.ModelType;
 import com.example.model.format.ChatFormat;
 import com.example.tokenizer.impl.Phi3Tokenizer;
@@ -22,7 +22,7 @@ public class Phi3 extends AbstractModel {
 
     Phi3Configuration configuration;
 
-    protected Phi3(Phi3Configuration configuration, Tokenizer tokenizer, Weights weights, ChatFormat chatFormat) {
+    public Phi3(Phi3Configuration configuration, Tokenizer tokenizer, Weights weights, ChatFormat chatFormat) {
         super(tokenizer, weights, chatFormat, null);
         this.configuration = configuration;
     }
@@ -49,7 +49,7 @@ public class Phi3 extends AbstractModel {
 
     @Override
     public State createNewState(int batchsize) {
-        State state = new Qwen3State(configuration(), batchsize);
+        State state = new Phi3State(configuration(), batchsize);
         state.latestToken = tokenizer.getSpecialTokens().get(chatFormat.chatTokens().tStartHeader());
         return state;
     }
@@ -57,7 +57,7 @@ public class Phi3 extends AbstractModel {
     @Override
     public void forward(State state, int token, int position) {
         if (plan == null) {
-            InferenceCore.forwardJavaPhi3(this, state, token, position);
+            InferenceCore.forwardJavaPhi3( this, (Phi3State) state, token, position);
         } else {
             InferenceCore.forwardTornadoVM(this, state, token, position, tornadoVMPlan());
         }
@@ -66,7 +66,7 @@ public class Phi3 extends AbstractModel {
     @Override
     public List<Integer> generateTokens(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated) {
-        return InferenceEngine.generateTokensPhi3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated);
+        return InferenceEngine.generateTokensQwen3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated);
     }
 
     @Override

--- a/src/main/java/com/example/model/phi3/Phi3.java
+++ b/src/main/java/com/example/model/phi3/Phi3.java
@@ -1,0 +1,63 @@
+package com.example.model.phi3;
+
+import com.example.inference.sampler.Sampler;
+import com.example.inference.state.State;
+import com.example.inference.weights.Weights;
+import com.example.model.AbstractModel;
+import com.example.model.Configuration;
+import com.example.model.ModelType;
+import com.example.model.format.ChatFormat;
+import com.example.tokenizer.impl.Tokenizer;
+import com.example.tornadovm.TornadoVMMasterPlan;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntConsumer;
+
+public class Phi3 extends AbstractModel {
+    protected Phi3(Tokenizer tokenizer, Weights weights, ChatFormat chatFormat, TornadoVMMasterPlan plan) {
+        super(tokenizer, weights, chatFormat, plan);
+    }
+
+    @Override
+    public Configuration configuration() {
+        return null;
+    }
+
+    @Override
+    public Tokenizer tokenizer() {
+        return null;
+    }
+
+    @Override
+    public ModelType getModelType() {
+        return null;
+    }
+
+    @Override
+    public State createNewState() {
+        return null;
+    }
+
+    @Override
+    public State createNewState(int batchsize) {
+        return null;
+    }
+
+    @Override
+    public void forward(State state, int token, int position) {
+
+    }
+
+    @Override
+    public List<Integer> generateTokens(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
+            IntConsumer onTokenGenerated) {
+        return List.of();
+    }
+
+    @Override
+    public List<Integer> generateTokensGPU(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
+            IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
+        return List.of();
+    }
+}

--- a/src/main/java/com/example/model/phi3/Phi3.java
+++ b/src/main/java/com/example/model/phi3/Phi3.java
@@ -66,7 +66,7 @@ public class Phi3 extends AbstractModel {
     @Override
     public List<Integer> generateTokens(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated) {
-        return InferenceEngine.generateTokensQwen3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated);
+        return InferenceEngine.generateTokensPhi3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated);
     }
 
     @Override

--- a/src/main/java/com/example/model/phi3/Phi3.java
+++ b/src/main/java/com/example/model/phi3/Phi3.java
@@ -1,12 +1,16 @@
 package com.example.model.phi3;
 
+import com.example.inference.InferenceCore;
+import com.example.inference.InferenceEngine;
 import com.example.inference.sampler.Sampler;
+import com.example.inference.state.Phi3State;
+import com.example.inference.state.Qwen3State;
 import com.example.inference.state.State;
 import com.example.inference.weights.Weights;
 import com.example.model.AbstractModel;
-import com.example.model.Configuration;
 import com.example.model.ModelType;
 import com.example.model.format.ChatFormat;
+import com.example.tokenizer.impl.Phi3Tokenizer;
 import com.example.tokenizer.impl.Tokenizer;
 import com.example.tornadovm.TornadoVMMasterPlan;
 
@@ -15,49 +19,59 @@ import java.util.Set;
 import java.util.function.IntConsumer;
 
 public class Phi3 extends AbstractModel {
-    protected Phi3(Tokenizer tokenizer, Weights weights, ChatFormat chatFormat, TornadoVMMasterPlan plan) {
-        super(tokenizer, weights, chatFormat, plan);
+
+    Phi3Configuration configuration;
+
+    protected Phi3(Phi3Configuration configuration, Tokenizer tokenizer, Weights weights, ChatFormat chatFormat) {
+        super(tokenizer, weights, chatFormat, null);
+        this.configuration = configuration;
     }
 
-    @Override
-    public Configuration configuration() {
-        return null;
+    public Phi3Configuration configuration() {
+        return configuration;
     }
 
-    @Override
-    public Tokenizer tokenizer() {
-        return null;
+    public Phi3Tokenizer tokenizer() {
+        return (Phi3Tokenizer) tokenizer;
     }
 
     @Override
     public ModelType getModelType() {
-        return null;
+        return ModelType.PHI_3;
     }
 
     @Override
     public State createNewState() {
-        return null;
+        State state = new Phi3State(configuration(), -1);
+        state.latestToken = tokenizer.getSpecialTokens().get(chatFormat.chatTokens().tStartHeader());
+        return state;
     }
 
     @Override
     public State createNewState(int batchsize) {
-        return null;
+        State state = new Qwen3State(configuration(), batchsize);
+        state.latestToken = tokenizer.getSpecialTokens().get(chatFormat.chatTokens().tStartHeader());
+        return state;
     }
 
     @Override
     public void forward(State state, int token, int position) {
-
+        if (plan == null) {
+            InferenceCore.forwardJavaPhi3(this, state, token, position);
+        } else {
+            InferenceCore.forwardTornadoVM(this, state, token, position, tornadoVMPlan());
+        }
     }
 
     @Override
     public List<Integer> generateTokens(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated) {
-        return List.of();
+        return InferenceEngine.generateTokensPhi3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated);
     }
 
     @Override
     public List<Integer> generateTokensGPU(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
-        return List.of();
+        return InferenceEngine.generateTokensGPUPhi3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated, tornadoVMPlan);
     }
 }

--- a/src/main/java/com/example/model/phi3/Phi3Configuration.java
+++ b/src/main/java/com/example/model/phi3/Phi3Configuration.java
@@ -18,17 +18,17 @@ public record Phi3Configuration(int dim,
                                     float ropeTheta) implements Configuration {
     @Override
     public int headSize() {
-        throw new UnsupportedOperationException("Not supported for Qwen3.");
+        throw new UnsupportedOperationException("Not supported for Phi3.");
     }
 
     @Override
     public int kvDim() {
-        throw new UnsupportedOperationException("Not supported for Qwen3.");
+        throw new UnsupportedOperationException("Not supported for Phi3.");
     }
 
     @Override
     public int kvMul() {
-        throw new UnsupportedOperationException("Not supported for Qwen3.");
+        throw new UnsupportedOperationException("Not supported for Phi3.");
     }
 
     @Override

--- a/src/main/java/com/example/model/phi3/Phi3Configuration.java
+++ b/src/main/java/com/example/model/phi3/Phi3Configuration.java
@@ -1,0 +1,38 @@
+package com.example.model.phi3;
+
+import com.example.model.Configuration;
+
+// @formatter:off
+public record Phi3Configuration(int dim,
+                                    int hiddenDim,
+                                    int numberOfLayers,
+                                    int numberOfHeads,
+                                    int numberOfKeyValueHeads,
+                                    int numberOfHeadsKey,
+                                    int numberOfHeadsValue,
+                                    int vocabularySize,
+                                    int contextLengthModel,
+                                    int contextLength,
+                                    boolean sharedWeights,
+                                    float rmsNormEps,
+                                    float ropeTheta) implements Configuration {
+    @Override
+    public int headSize() {
+        throw new UnsupportedOperationException("Not supported for Qwen3.");
+    }
+
+    @Override
+    public int kvDim() {
+        throw new UnsupportedOperationException("Not supported for Qwen3.");
+    }
+
+    @Override
+    public int kvMul() {
+        throw new UnsupportedOperationException("Not supported for Qwen3.");
+    }
+
+    @Override
+    public int contextLengthModel() {
+        return contextLengthModel;
+    }
+}

--- a/src/main/java/com/example/model/phi3/Phi3Configuration.java
+++ b/src/main/java/com/example/model/phi3/Phi3Configuration.java
@@ -4,35 +4,41 @@ import com.example.model.Configuration;
 
 // @formatter:off
 public record Phi3Configuration(int dim,
-                                    int hiddenDim,
-                                    int numberOfLayers,
-                                    int numberOfHeads,
-                                    int numberOfKeyValueHeads,
-                                    int numberOfHeadsKey,
-                                    int numberOfHeadsValue,
-                                    int vocabularySize,
-                                    int contextLengthModel,
-                                    int contextLength,
-                                    boolean sharedWeights,
-                                    float rmsNormEps,
-                                    float ropeTheta) implements Configuration {
+                                int hiddenDim,
+                                int numberOfLayers,
+                                int numberOfHeads,
+                                int numberOfKeyValueHeads,
+                                int vocabularySize,
+                                int contextLength,
+                                float rmsNormEps,
+                                float ropeTheta) implements Configuration {
+
+    @Override
+    public int numberOfHeadsKey() {
+        // For Phi3, key heads are the same as key-value heads
+        return numberOfKeyValueHeads;
+    }
+
     @Override
     public int headSize() {
-        throw new UnsupportedOperationException("Not supported for Phi3.");
+        // Calculate head size from dim and numberOfHeads
+        return dim / numberOfHeads;
     }
 
     @Override
     public int kvDim() {
-        throw new UnsupportedOperationException("Not supported for Phi3.");
+        // Calculate key-value dimension
+        return (dim * numberOfKeyValueHeads) / numberOfHeads;
     }
 
     @Override
     public int kvMul() {
-        throw new UnsupportedOperationException("Not supported for Phi3.");
+        // Calculate key-value multiplier for multi-query attention
+        return numberOfHeads / numberOfKeyValueHeads;
     }
 
     @Override
     public int contextLengthModel() {
-        return contextLengthModel;
+        return contextLength;
     }
 }

--- a/src/main/java/com/example/tokenizer/impl/Phi3Tokenizer.java
+++ b/src/main/java/com/example/tokenizer/impl/Phi3Tokenizer.java
@@ -33,12 +33,15 @@ public class Phi3Tokenizer implements Tokenizer {
     private final int[] tokenType;
     private final int byte0;
 
+    /** Number of base tokens in the vocabulary; tokens after this index are considered special. */
+    private static final int BASE_TOKENS = 32000;
+
     public Phi3Tokenizer(Map<String, Object> metadata, Vocabulary vocabulary) {
         int[] tokenTypes = (int[]) metadata.get("tokenizer.ggml.token_type");
         List<Pair<Integer, Integer>> merges = Collections.emptyList();
 
         int allTokens = vocabulary.size();
-        int baseTokens = 32000; // assume all tokens after the base ones are special.
+        int baseTokens = BASE_TOKENS; // assume all tokens after the base ones are special.
         //int reservedSpecialTokens = allTokens - baseTokens;
         List<String> specialTokensList = Arrays.stream(vocabulary.tokens(), baseTokens, allTokens).toList();
 

--- a/src/main/java/com/example/tokenizer/impl/Phi3Tokenizer.java
+++ b/src/main/java/com/example/tokenizer/impl/Phi3Tokenizer.java
@@ -1,0 +1,119 @@
+package com.example.tokenizer.impl;
+
+import com.example.tokenizer.vocabulary.Vocabulary;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Phi3Tokenizer implements Tokenizer {
+
+    private static final String SPM_UNDERSCORE = "\u2581";
+    private static final String PHI3_PATTERN = "\\S+|\\s+"; // Define appropriate pattern for Phi3
+    private final Vocabulary vocabulary;
+    // general fields
+    private final Pattern compiledPattern;
+    // model-specific fields
+    private final Map<String, Integer> specialTokens;
+    private final int[] tokenType;
+    private final int byte0;
+
+    public Phi3Tokenizer(Map<String, Object> metadata, Vocabulary vocabulary) {
+        // load from metadata
+        int[] tokenTypes = (int[]) metadata.get("tokenizer.ggml.token_type");
+        List<Integer> specialTokensList = IntStream.range(0, vocabulary.size()).filter(t -> tokenTypes[t] != 1 && tokenTypes[t] != 6).boxed().toList();
+        Map<String, Integer> specialTokens = IntStream.range(0, specialTokensList.size()).boxed().collect(Collectors.toMap(t -> vocabulary.get(specialTokensList.get(t)), specialTokensList::get));
+
+        // init tokenizer object fields
+        this.vocabulary = vocabulary;
+        this.compiledPattern = Pattern.compile(PHI3_PATTERN);
+        this.specialTokens = new HashMap<>(specialTokens);
+        this.tokenType = tokenTypes;
+        this.byte0 = vocabulary.getIndex("<0x00>").orElseThrow();
+    }
+
+    @Override
+    public String regexPattern() {
+        return "";
+    }
+
+    @Override
+    public Map<String, Integer> getSpecialTokens() {
+        return Map.of();
+    }
+
+    @Override
+    public boolean isSpecialToken(int tokenIndex) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldDisplayToken(int token) {
+        return false;
+    }
+
+    @Override
+    public List<Integer> encode(String text, Set<String> allowedSpecial) {
+        return List.of();
+    }
+
+    @Override
+    public List<Integer> encodeAsList(String pText) {
+        String text = pText.replace(" ", SPM_UNDERSCORE);
+        text = pText.startsWith(SPM_UNDERSCORE) ? text : SPM_UNDERSCORE + text;
+        final int textLen = text.length();
+
+        final List<Integer> tokens = new ArrayList<>();
+        final int vocSize = vocabulary.size();
+        int offset = 0;
+        while (offset < textLen) {
+            String curVoc = null;
+            int token = -1;
+            for (int j = 0; j < vocSize; j++) {
+                final String voc = vocabulary.get(j);
+                if (text.startsWith(voc, offset) && (curVoc == null || curVoc.length() < voc.length())) {
+                    curVoc = voc;
+                    token = j;
+                }
+            }
+            if (curVoc == null) {
+                // Try <0xE7>... of character or surrogate (emoji).
+                final int len = (offset + 1 < textLen) && Character.isHighSurrogate(text.charAt(offset)) ? 2 : 1;
+                final byte[] bufUtf8 = text.substring(offset, offset + len).getBytes(StandardCharsets.UTF_8);
+                for (int i = 0; i < bufUtf8.length; i++) {
+                    final String sHex = String.format("<0x%02x>", bufUtf8[i] & 0xff);
+                    token = -1;
+                    for (int j = 0; j < vocSize; j++) {
+                        if (sHex.equalsIgnoreCase(vocabulary.get(j))) {
+                            token = j;
+                        }
+                    }
+                    if (token == -1) {
+                        throw new RuntimeException(String.format("Can't tokenize text at offset %d (%c / (%d, sHex %s)), tokens = %s, text: %s", offset, text.charAt(offset), i, sHex, tokens, text));
+                    }
+                    tokens.add(token);
+                }
+                offset += len;
+                continue;
+            }
+            tokens.add(token);
+            offset += curVoc.length();
+        }
+        return tokens;
+    }
+
+    @Override
+    public String decode(List<Integer> tokens) {
+        final StringBuilder sb = new StringBuilder();
+        for (Integer token : tokens) {
+            sb.append(vocabulary.get(token));
+        }
+        return sb.toString().replace(SPM_UNDERSCORE, " ");
+    }
+}

--- a/src/main/java/com/example/tokenizer/impl/Phi3Tokenizer.java
+++ b/src/main/java/com/example/tokenizer/impl/Phi3Tokenizer.java
@@ -73,12 +73,12 @@ public class Phi3Tokenizer implements Tokenizer {
 
     @Override
     public boolean isSpecialToken(int tokenIndex) {
-        return false;
+        return specialTokens.containsValue(tokenIndex);
     }
 
     @Override
     public boolean shouldDisplayToken(int token) {
-        return false;
+        return !isSpecialToken(token);
     }
 
     @Override

--- a/src/main/java/com/example/tokenizer/vocabulary/Vocabulary.java
+++ b/src/main/java/com/example/tokenizer/vocabulary/Vocabulary.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public record Vocabulary(String[] tokens, float[] scores, Map<String, Integer> tokenToIndex) {
-    private static final String TOKENIZER_LLAMA_3_MODEL = "gpt2";
 
     // @formatter:off
     public Vocabulary(String[] vocabulary, float[] scores) {

--- a/src/main/java/com/example/tokenizer/vocabulary/Vocabulary.java
+++ b/src/main/java/com/example/tokenizer/vocabulary/Vocabulary.java
@@ -45,6 +45,12 @@ public record Vocabulary(String[] tokens, float[] scores, Map<String, Integer> t
         return new Vocabulary(tokens, scores);
     }
 
+    public static Vocabulary loadPhi3Vocabulary(Map<String, Object> metadata) {
+        String[] tokens = (String[]) metadata.get("tokenizer.ggml.tokens");
+        float[] scores = (float[]) metadata.get("tokenizer.ggml.scores");
+        return new Vocabulary(tokens, scores);
+    }
+
     public int size() {
         return tokens.length;
     }

--- a/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
@@ -266,7 +266,7 @@ public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, 
 
         int qkvmatmulDimRowMajorGlobal = opSize * LOCAL_WORK_GROUP_SIZE_ALLOC;
         WorkerGrid qkvDimRowMajorGlobalWorker = new WorkerGrid1D(qkvmatmulDimRowMajorGlobal);
-        configDimRowMajorGlobalWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
+        qkvDimRowMajorGlobalWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
 
 
         // config.kvDim Worker for Row major access
@@ -346,7 +346,7 @@ public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, 
             tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".rope", ropeWorker);
             tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".matmul1", configDimRowMajorGlobalWorker);
             tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".wDown", configDimRowMajorGlobalWorker);
-            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".wGateup", wgetHiddenDimRowMajorWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".wGateUp", wgetHiddenDimRowMajorWorker);
             tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".reductionsOneBlock", rmsNormWorker);
             tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".mapContext", rmsNormWorker);
             tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".reductionsOneBlockFFN", rmsNormWorker);

--- a/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
@@ -320,8 +320,6 @@ public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, 
         splitQKVWorker.setGlobalWork(opSize, 1, 1);
         splitQKVWorker.setLocalWork(128, 1, 1);
 
-        // Map to task
-
         // Map workers to tasks
         tornadoForwardScheduler.addWorkerGrid("activationUpdate.updateX", singleWorker);
         for (int i = 0; i < config.numberOfLayers(); i++) {

--- a/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
@@ -87,7 +87,7 @@ public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, 
                     // .task("wDown", ...)
 
                     // After (1 fused task):
-                    .task("fusedFFN", TransformerComputeKernelsLayered::fusedGateUpSiLUDownOptimized, context,
+                    .task("fusedFFN", TransformerComputeKernelsLayered::fusedGateUpSiLUDown, context,
                             state.wrapXb, state.wrapX, weights.wUpLayered[layerIndex],
                             weights.wDownLayered[layerIndex], config.dim(), config.hiddenDim(),
                             LOCAL_WORK_GROUP_SIZE_ALLOC)

--- a/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
@@ -1,0 +1,377 @@
+package com.example.tornadovm;
+
+import com.example.auxiliary.Tuple2;
+import com.example.inference.state.Phi3State;
+import com.example.inference.weights.tornado.Phi3TornadoWeights;
+import com.example.model.Model;
+import com.example.model.phi3.Phi3Configuration;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, Phi3Configuration, Phi3TornadoWeights> {
+
+    /**
+     * Constructs a TornadoVMLayerPlanner for the given Llama model.
+     *
+     * @param state
+     *         The state object containing model tensors and buffers
+     * @param model
+     *         The Llama model instance containing configuration and weights
+     */
+    public Phi3TornadoVMLayerPlanner(Phi3State state, Model model) {
+        super(state, model);
+    }
+
+    public Tuple2<List<ImmutableTaskGraph>, GridScheduler> setupTornadoForwardPlanLayered() {
+        List<ImmutableTaskGraph> taskGraphs = new ArrayList<>();
+
+        state.temp.init(0.0f);
+        state.tempFFN.init(0.0f);
+        state.tempLogits.init(0.0f);
+        final int opSize = config.dim() + 2 * (config.numberOfKeyValueHeads() * config.headSize());
+
+        // @formatter:off
+        TaskGraph activationUpdate = new TaskGraph("activationUpdate")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, state.wrapX)
+                .task("updateX", TransformerComputeKernels::emptyTaskToForceCopyIn, state.wrapX)
+                .persistOnDevice(state.wrapX);
+        taskGraphs.add(activationUpdate.snapshot());
+
+        TaskGraph unifiedLayer = null;
+        for (int layerIndex =0; layerIndex < config.numberOfLayers(); layerIndex++) {
+            unifiedLayer = new TaskGraph("layer_" + layerIndex);
+            unifiedLayer.consumeFromDevice(state.wrapX);
+            unifiedLayer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    //Copy-in weights per layer for batched-layered layout
+                    weights.rms_att_weightLayered[layerIndex],
+//                    weights.wqLayered[layerIndex],
+//                    weights.wkLayered[layerIndex],
+//                    weights.wvLayered[layerIndex],
+                    weights.wqkvLayered[layerIndex],
+                    weights.woLayered[layerIndex],
+                    weights.rms_ffn_weightLayered[layerIndex],
+                    weights.wDownLayered[layerIndex],
+                    weights.wUpLayered[layerIndex]
+//                    weights.w1Layered[layerIndex],
+//                    weights.w2Layered[layerIndex],
+//                    weights.w3Layered[layerIndex]
+            );
+            unifiedLayer = configureLayerDataTransfers(unifiedLayer, layerIndex);
+            unifiedLayer.task("reductionsOneBlock" , TransformerComputeKernelsLayered::reductionOneBlockWithLayer, context, state.temp,
+                            state.wrapX, config.dim(), config.rmsNormEps(), state.localSize)
+                    .task("mapContext", TransformerComputeKernelsLayered::reductionOneBlock2WithLayer, context, state.wrapXb,
+                            state.wrapX, weights.rms_att_weightLayered[layerIndex], state.temp)
+                    .task("qkvmatmul", TransformerComputeKernelsLayered::matrixVectorGeneric, context, state.wrapXb, state.wrapQkv,
+                            weights.wqkvLayered[layerIndex], config.dim(), opSize, LOCAL_WORK_GROUP_SIZE_ALLOC)
+                    .task("copyQ", TransformerComputeKernelsLayered::copyTo,
+                            state.wrapQkv, 0, state.wrapQ,0, config.dim())
+                    .task("copyK", TransformerComputeKernelsLayered::copyTo,
+                            state.wrapQkv, config.dim(), state.wrapK, 0, config.headSize() * config.numberOfKeyValueHeads())
+                    .task("copyV", TransformerComputeKernelsLayered::copyTo,
+                            state.wrapQkv, config.dim() + config.headSize() * config.numberOfKeyValueHeads(),
+                            state.wrapV, 0, config.headSize() * config.numberOfKeyValueHeads())
+                    .task("rope", TransformerComputeKernelsLayered::ropeRotation,context,
+                            state.positionHolder, state.wrapQ, state.wrapK, config.kvDim(),
+                            config.headSize())
+                    .task("copyToCaches", TransformerComputeKernelsLayered::copyToCache,
+                            state.wrapKeyCache, state.wrapK,  state.wrapValueCache, state.wrapV, state.positionHolder, config.kvDim(), layerIndex, config.contextLength())
+                    .task("parallel-attention", TransformerComputeKernelsLayered::processHeadsFlashAttention, context,
+                            state.wrapQ, state.wrapKeyCache, state.wrapValueCache, state.wrapXb,
+                            config.numberOfHeads(), config.headSize(), config.kvDim(), config.kvMul(),
+                            state.positionHolder, layerIndex, config.contextLength())
+                    .task("matmul1", TransformerComputeKernelsLayered::matrixVectorGenericWithResidual, context,
+                            state.wrapXb,  state.wrapX, weights.woLayered[layerIndex], config.dim(), config.dim(),  LOCAL_WORK_GROUP_SIZE_ALLOC)
+                    .task("reductionsOneBlockFFN", TransformerComputeKernelsLayered::reductionOneBlockWithLayer, context, state.tempFFN,
+                            state.wrapX, config.dim(), config.rmsNormEps(), state.localSize)
+                    .task("mapContextFFN", TransformerComputeKernelsLayered::reductionOneBlock2WithLayer, context, state.wrapXb,
+                            state.wrapX, weights.rms_ffn_weightLayered[layerIndex], state.tempFFN)
+                    .task("wGateUp", TransformerComputeKernelsLayered::matrixVectorGeneric, context,
+                            state.wrapXb,   state.wrapHb, weights.wUpLayered[layerIndex],  config.dim(), 2 * config.hiddenDim(),  LOCAL_WORK_GROUP_SIZE_ALLOC)
+                    // Copy gate chunk: hb[0:hiddenDim] -> hbG[0:hiddenDim]
+                    .task("copyGate", TransformerComputeKernelsLayered::copyChunk,
+                            state.wrapHb, state.wrapHbG, 2 * config.hiddenDim(), config.hiddenDim(), 2, 0)
+                    // Copy up chunk: hb[hiddenDim:2*hiddenDim] -> hbU[0:hiddenDim]
+                    .task("copyUp", TransformerComputeKernelsLayered::copyChunk,
+                            state.wrapHb, state.wrapHbU, 2 * config.hiddenDim(), config.hiddenDim(), 2, 1)
+                    // Apply SiLU activation to gate: hbG = silu(hbG)
+                    .task("siluActivation", TransformerComputeKernelsLayered::siluInPlace,
+                            state.wrapHbG, config.hiddenDim())
+                    // Element-wise multiply: hbU = hbU * hbG
+                    .task("gatedMultiply", TransformerComputeKernelsLayered::multiplyInPlace,
+                            state.wrapHbU, state.wrapHbG, config.hiddenDim())
+                    .task("wDown", TransformerComputeKernelsLayered::matrixVectorGenericWithResidual, context,
+                            state.wrapHbU, state.wrapX, weights.wDownLayered[layerIndex], config.hiddenDim(), config.dim(),  LOCAL_WORK_GROUP_SIZE_ALLOC)
+                    .persistOnDevice(
+                            state.wrapX
+                    );
+            taskGraphs.add(unifiedLayer.snapshot());
+        }
+
+        TaskGraph lastUnifiedLayer = unifiedLayer;
+        TaskGraph logits = new TaskGraph("logits")
+                .consumeFromDevice(lastUnifiedLayer.getTaskGraphName(),
+                        state.wrapX
+                )
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION,
+                        state.tempLogits
+                )
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                        context,
+                        state.wrapLogits,
+                        weights.wclsHalfFloat,
+                        weights.rms_final_weight_as_floatArray
+                )
+                .task("reductionsOneBlockLogits", TransformerComputeKernels::reductionOneBlockWithLayer, context, state.tempLogits,
+                        state.wrapX, config.dim(), config.rmsNormEps(), state.localSize)
+                .task("mapContextLogits", TransformerComputeKernels::reductionOneBlock2WithLogits, context, state.wrapX,
+                        weights.rms_final_weight_as_floatArray, state.tempLogits);
+        logits = configureQuantizedMatrixVectorFinalWeight(logits);
+        logits.transferToHost(DataTransferMode.EVERY_EXECUTION, state.wrapLogits);
+        taskGraphs.add(logits.snapshot());
+        // @formatter:on
+
+        return new Tuple2<>(taskGraphs, setupGridSchedulersLayered());
+    }
+
+    // @formatter:off
+    /**
+     * Configures the final projection layer in the task graph based on weight quantization type.
+     *
+     * This method adds a "projection" task to compute the final logits by performing a
+     * matrix-vector multiplication between the model's output embeddings and the classifier
+     * weights (wcls). The computation kernel used depends on the quantization format.
+     *
+     * Supported quantization types:
+     * - Q8_0: 8-bit quantization with uniform scaling per 32-element block
+     * - Q4_0: 4-bit quantization with uniform scaling per 32-element block
+     *
+     * The task multiplies:
+     * - weights.wclsByteArray: Quantized classifier weights (vocab_size x dim)
+     * - state.wrapX: Current layer output (dim)
+     * - Result: state.wrapLogits: Raw logits (vocab_size)
+     *
+     * @param logits The existing task graph to extend with the projection operation
+     * @return The modified task graph with the projection task added
+     * @throws UnsupportedOperationException If weights.weightType is not Q8_0 or Q4_0
+     */
+    // @formatter:on
+    protected TaskGraph configureQuantizedMatrixVectorFinalWeight(TaskGraph logits) {
+        switch (weights.getWeightType()) {
+            case F16:
+            case Q8_0:
+            case Q4_0:
+                logits.task("projection", TransformerComputeKernelsLayered::matrixVectorGeneric,  //
+                        context, state.wrapX, state.wrapLogits, weights.wclsHalfFloat, //
+                        config.dim(), config.vocabularySize(), LOCAL_WORK_GROUP_SIZE_ALLOC * THREAD_SCALE_FOR_LOGITS); //
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported weight quantization type: " + weights.getWeightType() + ". Only Q8_0 and Q4_0 are supported.");
+        }
+        return logits;
+    }
+
+    /**
+     * Configures data transfer operations for a specific layer in the neural network task graph.
+     *
+     * This method manages GPU memory transfers with optimized data movement strategies: This optimization pattern minimizes data movement by: 1. Using one-time transfers for static data 2. Reusing
+     * intermediate results already on GPU from previous layers 3. Only transferring // dynamic data that changes per execution
+     *
+     * @param unifiedLayer
+     *         The task graph representing this layer's operations
+     * @param layerIndex
+     *         Index of the current layer (0-based)
+     * @return The configured task graph with appropriate data transfer operations
+     */
+    protected TaskGraph configureLayerDataTransfers(TaskGraph unifiedLayer, int layerIndex) {
+        // First layer: Transfer initial data to device (one-time transfer)
+        if (layerIndex == 0) {
+            // Transfer all attention-related data: query, key, value matrices and their caches
+            unifiedLayer.transferToDevice(DataTransferMode.EVERY_EXECUTION, state.positionHolder, state.temp, state.tempFFN); //
+            unifiedLayer.transferToDevice(DataTransferMode.FIRST_EXECUTION, //
+                    context, state.wrapXb, state.wrapXb2, //
+                    state.wrapQ, state.wrapK, state.wrapV, //
+                    state.wrapKeyCache, state.wrapValueCache, //
+                    state.wrapAtt, state.wrapHb, //
+                    state.wrapHbG, state.wrapHbU, state.wrapQkv); //
+        } else {
+            // Subsequent layers: Consume data already on device from previous layer
+            unifiedLayer.consumeFromDevice(context, state.wrapXb, state.wrapXb2, //
+                    state.wrapQ, state.wrapK, state.wrapV, //
+                    state.wrapKeyCache, state.wrapValueCache, //
+                    state.wrapAtt, state.wrapHb, //
+                    state.positionHolder, // /
+                    state.wrapHbG, state.wrapHbU, state.wrapQkv
+                    // /
+            );
+        }
+        return unifiedLayer;
+    }
+
+    // @formatter:off
+    /**
+     * Sets up the grid scheduler configuration for a layered neural network forward pass.
+     *
+     * This method creates and configures worker grids for different types of GPU operations
+     * in the transformer/ML model pipeline. Each worker grid defines how work should be
+     * distributed across GPU threads (OpenCL work-items or CUDA threads).
+     *
+     * The method creates several worker profiles:
+     * - Single thread operations (activation updates)
+     * - RoPE (Rotary Position Embedding) operations
+     * - Matrix multiplications with different dimensions
+     * - RMS normalization operations
+     * - Parallel attention computations
+     * - Cache copying operations
+     * - Vocabulary projections
+     *
+     * Each worker grid maps to equivalent OpenCL NDRange or CUDA grid/block configurations:
+     * - setGlobalWork() ≈ OpenCL global_work_size ≈ CUDA grid dimensions × block dimensions
+     * - setLocalWork() ≈ OpenCL local_work_size ≈ CUDA block dimensions
+     *
+     * @return GridScheduler configured with all necessary worker grids for the model layers
+     */
+    // @formatter:on
+    private GridScheduler setupGridSchedulersLayered() {
+        GridScheduler tornadoForwardScheduler = new GridScheduler();
+
+        // Single worker for tasks running with a single thread
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[1,1,1], localWorkSize=[1,1,1])
+        // CUDA equivalent: kernel<<<dim3(1,1,1), dim3(1,1,1)>>>
+        WorkerGrid singleWorker = new WorkerGrid1D(1);
+        singleWorker.setGlobalWork(1, 1, 1);
+        singleWorker.setLocalWork(1, 1, 1);
+
+        // config.dim / 2 Worker for RoPE
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.dim/2,1,1], localWorkSize=[128,1,1])
+        // CUDA equivalent: kernel<<<dim3((config.dim/2+127)/128,1,1), dim3(128,1,1)>>>
+        WorkerGrid ropeWorker = new WorkerGrid1D(config.dim() / 2);
+        ropeWorker.setGlobalWork(config.dim() / 2, 1, 1);
+        ropeWorker.setLocalWork(128, 1, 1);
+
+        // config.dim Worker for Row major access
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.dim*LOCAL_WORK_GROUP_SIZE_ALLOC,1,1], localWorkSize=[LOCAL_WORK_GROUP_SIZE_ALLOC,1,1])
+        // CUDA equivalent: kernel<<<dim3(config.dim,1,1), dim3(LOCAL_WORK_GROUP_SIZE_ALLOC,1,1)>>>
+        int configDimRowMajorGlobal = config.dim() * LOCAL_WORK_GROUP_SIZE_ALLOC;
+        WorkerGrid configDimRowMajorGlobalWorker = new WorkerGrid1D(configDimRowMajorGlobal);
+        configDimRowMajorGlobalWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
+
+        final int opSize = config.dim() + 2 * (config.numberOfKeyValueHeads() * config.headSize());
+
+        int qkvmatmulDimRowMajorGlobal = opSize * LOCAL_WORK_GROUP_SIZE_ALLOC;
+        WorkerGrid qkvDimRowMajorGlobalWorker = new WorkerGrid1D(qkvmatmulDimRowMajorGlobal);
+        configDimRowMajorGlobalWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
+
+
+        // config.kvDim Worker for Row major access
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.kvDim*LOCAL_WORK_GROUP_SIZE_ALLOC,1,1], localWorkSize=[LOCAL_WORK_GROUP_SIZE_ALLOC,1,1])
+        // CUDA equivalent: kernel<<<dim3(config.kvDim,1,1), dim3(LOCAL_WORK_GROUP_SIZE_ALLOC,1,1)>>>
+        int configKvDimRowMajorGlobal = config.kvDim() * LOCAL_WORK_GROUP_SIZE_ALLOC;
+        WorkerGrid configKvDimRowMajorGlobalWorker = new WorkerGrid1D(configKvDimRowMajorGlobal);
+        configKvDimRowMajorGlobalWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
+
+        // config.hiddenDim * 32 Worker for Row major access
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.hiddenDim*LOCAL_WORK_GROUP_SIZE_ALLOC,1,1], localWorkSize=[LOCAL_WORK_GROUP_SIZE_ALLOC,1,1])
+        // CUDA equivalent: kernel<<<dim3(config.hiddenDim,1,1), dim3(LOCAL_WORK_GROUP_SIZE_ALLOC,1,1)>>>
+        int configHiddenDimRowMajor = config.hiddenDim() * LOCAL_WORK_GROUP_SIZE_ALLOC;
+        WorkerGrid configHiddenDimRowMajorWorker = new WorkerGrid1D(configHiddenDimRowMajor);
+        configHiddenDimRowMajorWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
+
+        int wgetUPDimRowMajor = 2 * config.hiddenDim() * LOCAL_WORK_GROUP_SIZE_ALLOC;
+        WorkerGrid wgetHiddenDimRowMajorWorker = new WorkerGrid1D(wgetUPDimRowMajor);
+        wgetHiddenDimRowMajorWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC, 1, 1);
+
+
+        // RMSNorm worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.dim,1,1], localWorkSize=[256,1,1])
+        // CUDA equivalent: kernel<<<dim3((config.dim+255)/256,1,1), dim3(256,1,1)>>>
+        WorkerGrid rmsNormWorker = new WorkerGrid1D(config.dim());
+        rmsNormWorker.setGlobalWork(config.dim(), 1, 1);  // Set global work size to total dimension
+        rmsNormWorker.setLocalWork(256, 1, 1);         // Set local work size to 256 (standard efficient size)
+
+        // Parallel attention worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.numberOfHeads,1,1], localWorkSize=[4,1,1])
+        // CUDA equivalent: kernel<<<dim3((config.numberOfHeads+3)/4,1,1), dim3(4,1,1)>>>
+        WorkerGrid parallelAttentionWorker = new WorkerGrid1D(config.numberOfHeads());
+        // the global group work size is numberOfHeads * localWorkGroupSize, where the localWorkGroupSize is currently 4
+        parallelAttentionWorker.setGlobalWork(config.numberOfHeads() * 8, 1, 1);
+        parallelAttentionWorker.setLocalWork(8, 1, 1); // Set local work size to 4 (for parallel attention)
+
+        // Copy to caches worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.dim,1,1], localWorkSize=[128,1,1])
+        // CUDA equivalent: kernel<<<dim3((config.dim+127)/128,1,1), dim3(128,1,1)>>>
+        WorkerGrid copyToCachesWorker = new WorkerGrid1D(config.kvDim());
+        copyToCachesWorker.setGlobalWork(config.dim(), 1, 1);
+        copyToCachesWorker.setLocalWork(128, 1, 1); // Set local work size to 32 (for copying to caches)
+
+        // Q copy worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.dim,1,1], localWorkSize=[128,1,1])
+        // CUDA equivalent: kernel<<<dim3((config.dim+127)/128,1,1), dim3(128,1,1)>>>
+        WorkerGrid copyQWorker = new WorkerGrid1D(config.dim());
+        copyQWorker.setGlobalWork(config.dim(), 1, 1);
+        copyQWorker.setLocalWork(128, 1, 1);
+
+        // K copy worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[kvSize,1,1], localWorkSize=[128,1,1])
+        // CUDA equivalent: kernel<<<dim3((kvSize+127)/128,1,1), dim3(128,1,1)>>>
+        int kvSize = config.headSize() * config.numberOfKeyValueHeads();
+        WorkerGrid copyKWorker = new WorkerGrid1D(kvSize);
+        copyKWorker.setGlobalWork(kvSize, 1, 1);
+        copyKWorker.setLocalWork(128, 1, 1);
+
+        // V copy worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[kvSize,1,1], localWorkSize=[128,1,1])
+        // CUDA equivalent: kernel<<<dim3((kvSize+127)/128,1,1), dim3(128,1,1)>>>
+        WorkerGrid copyVWorker = new WorkerGrid1D(kvSize);
+        copyVWorker.setGlobalWork(kvSize, 1, 1);
+        copyVWorker.setLocalWork(128, 1, 1);
+
+        WorkerGrid hiddenDimWorker = new WorkerGrid1D(config.hiddenDim());
+        hiddenDimWorker.setGlobalWork(config.hiddenDim(), 1, 1);
+        hiddenDimWorker.setLocalWork(128, 1, 1);
+
+        // Map workers to tasks
+        tornadoForwardScheduler.addWorkerGrid("activationUpdate.updateX", singleWorker);
+        for (int i = 0; i < config.numberOfLayers(); i++) {
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".qkvmatmul", qkvDimRowMajorGlobalWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".copyQ", copyQWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".copyK", copyKWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".copyV", copyVWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".rope", ropeWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".matmul1", configDimRowMajorGlobalWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".wDown", configDimRowMajorGlobalWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".wGateup", wgetHiddenDimRowMajorWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".reductionsOneBlock", rmsNormWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".mapContext", rmsNormWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".reductionsOneBlockFFN", rmsNormWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".mapContextFFN", rmsNormWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".parallel-attention", parallelAttentionWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".copyToCaches", copyToCachesWorker);
+            // New FFN tasks
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".copyGate", hiddenDimWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".copyUp", hiddenDimWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".siluActivation", hiddenDimWorker);
+            tornadoForwardScheduler.addWorkerGrid("layer_" + i + ".gatedMultiply", hiddenDimWorker);
+
+        }
+
+        // Vocabulary worker configuration
+        // OpenCL equivalent: clEnqueueNDRangeKernel(globalWorkSize=[config.vocabularySize,1,1], localWorkSize=[16,1,1])
+        // CUDA equivalent: kernel<<<dim3((config.vocabularySize+15)/16,1,1), dim3(16,1,1)>>>
+        int vocabSizeRowMajor = config.vocabularySize() * LOCAL_WORK_GROUP_SIZE_ALLOC * THREAD_SCALE_FOR_LOGITS;
+        WorkerGrid vocabWorker = new WorkerGrid1D(vocabSizeRowMajor);
+        vocabWorker.setLocalWork(LOCAL_WORK_GROUP_SIZE_ALLOC * THREAD_SCALE_FOR_LOGITS, 1, 1);
+
+        tornadoForwardScheduler.addWorkerGrid("logits.projection", vocabWorker);
+        tornadoForwardScheduler.addWorkerGrid("logits.reductionsOneBlockLogits", rmsNormWorker);
+        tornadoForwardScheduler.addWorkerGrid("logits.mapContextLogits", rmsNormWorker);
+
+        return tornadoForwardScheduler;
+    }
+}

--- a/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
@@ -45,7 +45,7 @@ public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, 
         taskGraphs.add(activationUpdate.snapshot());
 
         TaskGraph unifiedLayer = null;
-        for (int layerIndex =0; layerIndex < config.numberOfLayers(); layerIndex++) {
+        for (int layerIndex = 0; layerIndex < config.numberOfLayers(); layerIndex++) {
             unifiedLayer = new TaskGraph("layer_" + layerIndex);
             unifiedLayer.consumeFromDevice(state.wrapX);
             unifiedLayer.transferToDevice(DataTransferMode.FIRST_EXECUTION,

--- a/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
+++ b/src/main/java/com/example/tornadovm/Phi3TornadoVMLayerPlanner.java
@@ -77,7 +77,7 @@ public class Phi3TornadoVMLayerPlanner extends TornadoVMLayerPlanner<Phi3State, 
                     .task("copyV", TransformerComputeKernelsLayered::copyTo,
                             state.wrapQkv, config.dim() + config.headSize() * config.numberOfKeyValueHeads(),
                             state.wrapV, 0, config.headSize() * config.numberOfKeyValueHeads())
-                    .task("rope", TransformerComputeKernelsLayered::ropeRotation,context,
+                    .task("rope", TransformerComputeKernelsLayered::ropeRotationPhi3,context,
                             state.positionHolder, state.wrapQ, state.wrapK, config.kvDim(),
                             config.headSize())
                     .task("copyToCaches", TransformerComputeKernelsLayered::copyToCache,

--- a/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
+++ b/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
@@ -99,6 +99,7 @@ public class TornadoVMMasterPlan {
         return switch (model.getModelType()) {
             case LLAMA_3, MISTRAL -> new TornadoVMLayerPlanner(state, model);
             case QWEN_3 -> new Qwen3TornadoVMLayerPlanner((Qwen3State) state, model);
+            case PHI_3 -> null;
             case UNKNOWN -> throw new UnsupportedOperationException("Unknown model type");
         };
     }

--- a/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
+++ b/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
@@ -39,14 +39,13 @@ public class TornadoVMMasterPlan {
     }
 
     /**
-     * Initializes the TornadoVM plan for GPU acceleration with optional timing.
-     * This method handles:
-     * 1. Creation of the TornadoVM master plan
-     * 2. Warming up the JIT compiler for better performance
-     * 3. Copying read-only model weights to the GPU
+     * Initializes the TornadoVM plan for GPU acceleration with optional timing. This method handles: 1. Creation of the TornadoVM master plan 2. Warming up the JIT compiler for better performance 3.
+     * Copying read-only model weights to the GPU
      *
-     * @param state The model state containing KV cache
-     * @param model The Llama model instance
+     * @param state
+     *         The model state containing KV cache
+     * @param model
+     *         The Llama model instance
      * @return The initialized TornadoVMMasterPlan ready for inference
      */
     public static TornadoVMMasterPlan initializeTornadoVMPlan(State state, Model model) {
@@ -94,26 +93,13 @@ public class TornadoVMMasterPlan {
     }
 
     /**
-     * Dispatcher method to select the TornadoVMLayerPlanner for the model.
-     */
-    TornadoVMLayerPlanner createPlanner(State state, Model model) {
-        return switch (model.getModelType()) {
-            case LLAMA_3, MISTRAL -> new TornadoVMLayerPlanner(state, model);
-            case QWEN_3 -> new Qwen3TornadoVMLayerPlanner((Qwen3State) state, model);
-            case PHI_3 -> new Phi3TornadoVMLayerPlanner((Phi3State) state, model);
-            case UNKNOWN -> throw new UnsupportedOperationException("Unknown model type");
-        };
-    }
-
-    /**
-     * Determines whether the NVIDIA-specific scheduler should be used based on the current
-     * hardware backend and the model type.
+     * Determines whether the NVIDIA-specific scheduler should be used based on the current hardware backend and the model type.
      * <p>
-     * The scheduler is used only if the runtime is targeting an NVIDIA backend and the model
-     * is not of type {@code MISTRAL}. If either the hardware is not NVIDIA or the model is
-     * {@code MISTRAL}, the NVIDIA-specific scheduler should not be used.
+     * The scheduler is used only if the runtime is targeting an NVIDIA backend and the model is not of type {@code MISTRAL}. If either the hardware is not NVIDIA or the model is {@code MISTRAL}, the
+     * NVIDIA-specific scheduler should not be used.
      *
-     * @param model the model whose type may affect the scheduler decision
+     * @param model
+     *         the model whose type may affect the scheduler decision
      * @return {@code true} if the NVIDIA-specific scheduler should be used; {@code false} otherwise
      */
     public static boolean shouldUseNvidiaScheduler(Model model) {
@@ -129,8 +115,19 @@ public class TornadoVMMasterPlan {
     }
 
     /**
-     * Executes the forward pass of a LLaMA transformer model using TornadoVM acceleration.
-     *This method processes the transformer layers in sequence for a particular token position in the context
+     * Dispatcher method to select the TornadoVMLayerPlanner for the model.
+     */
+    TornadoVMLayerPlanner createPlanner(State state, Model model) {
+        return switch (model.getModelType()) {
+            case LLAMA_3, MISTRAL -> new TornadoVMLayerPlanner(state, model);
+            case QWEN_3 -> new Qwen3TornadoVMLayerPlanner((Qwen3State) state, model);
+            case PHI_3 -> new Phi3TornadoVMLayerPlanner((Phi3State) state, model);
+            case UNKNOWN -> throw new UnsupportedOperationException("Unknown model type");
+        };
+    }
+
+    /**
+     * Executes the forward pass of a LLaMA transformer model using TornadoVM acceleration. This method processes the transformer layers in sequence for a particular token position in the context
      * window.
      *
      * <p>The execution happens in three phases:
@@ -139,7 +136,6 @@ public class TornadoVMMasterPlan {
      *   <li>Sequential processing through each transformer layer using TornadoVM</li>
      *   <li>Final projection to logits using TornadoVM</li>
      * </ol>
-     *
      *
      * @param position
      *         The current position in the sequence being processed
@@ -183,7 +179,9 @@ public class TornadoVMMasterPlan {
 
     /**
      * Returns the graph index for the given transformer layer.
-     * @param layerIndex Index of the transformer layer (0-based)
+     *
+     * @param layerIndex
+     *         Index of the transformer layer (0-based)
      */
     private int getLayerGraphIndex(int layerIndex) {
         return 1 + layerIndex;
@@ -196,8 +194,7 @@ public class TornadoVMMasterPlan {
         return taskGraphs.size() - 1;
     }
 
-    /// Execute the forward pass of the LLaMA transformer model using TornadoVM acceleration
-    /// just once to copy the data into the read-only data layer.
+    /// Execute the forward pass of the LLaMA transformer model using TornadoVM acceleration just once to copy the data into the read-only data layer.
     public void forceCopyInReadOnlyDataLayered() {
         // Execute all TornadoVM graphs
         state.wrapX.init(0.0f);
@@ -216,9 +213,7 @@ public class TornadoVMMasterPlan {
     }
 
     /**
-     * Frees the device memory allocated for the TornadoVM execution plan.
-     * This method should be called when the execution plan is no longer needed
-     * to release resources and avoid memory leaks.
+     * Frees the device memory allocated for the TornadoVM execution plan. This method should be called when the execution plan is no longer needed to release resources and avoid memory leaks.
      */
     public void freeTornadoExecutionPlan() {
         executionPlan.freeDeviceMemory();

--- a/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
+++ b/src/main/java/com/example/tornadovm/TornadoVMMasterPlan.java
@@ -1,6 +1,7 @@
 package com.example.tornadovm;
 
 import com.example.auxiliary.Tuple2;
+import com.example.inference.state.Phi3State;
 import com.example.inference.state.Qwen3State;
 import com.example.inference.state.State;
 import com.example.model.Configuration;
@@ -99,7 +100,7 @@ public class TornadoVMMasterPlan {
         return switch (model.getModelType()) {
             case LLAMA_3, MISTRAL -> new TornadoVMLayerPlanner(state, model);
             case QWEN_3 -> new Qwen3TornadoVMLayerPlanner((Qwen3State) state, model);
-            case PHI_3 -> null;
+            case PHI_3 -> new Phi3TornadoVMLayerPlanner((Phi3State) state, model);
             case UNKNOWN -> throw new UnsupportedOperationException("Unknown model type");
         };
     }

--- a/src/main/java/com/example/tornadovm/TransformerComputeKernelsLayered.java
+++ b/src/main/java/com/example/tornadovm/TransformerComputeKernelsLayered.java
@@ -127,6 +127,22 @@ public class TransformerComputeKernelsLayered {
         }
     }
 
+
+    public static void copyTo(FloatArray src, int srcOffset, FloatArray dest, int destOffset, int size) {
+        // Generic copy: src[srcOffset:srcOffset+size] -> dest[destOffset:destOffset+size]
+        for (@Parallel int i = 0; i < size; i++) {
+            dest.set(destOffset + i, src.get(srcOffset + i));
+        }
+    }
+
+    public static void copyChunk(FloatArray in, FloatArray out, int dim1In, int dim1Out, int nChunks, int chunkNo) {
+        final int startOffsetInDim1 = chunkNo * dim1Out;
+
+        for (@Parallel int i = 0; i < dim1Out; i++) {
+            out.set(i, in.get(startOffsetInDim1 + i));
+        }
+    }
+
     /**
      * Applies Rotary Position Encoding (RoPE) to query and key vectors.
      * RoPE rotates pairs of dimensions based on their position in the sequence,
@@ -833,6 +849,23 @@ public class TransformerComputeKernelsLayered {
             ss += ermsNorm;
             ss = 1.0f / TornadoMath.sqrt(ss);
             output.set(0, ss);  // Store the final scale factor
+        }
+    }
+
+    public static void siluInPlace(FloatArray array, int size) {
+        // SiLU activation: silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
+        for (@Parallel int i = 0; i < size; i++) {
+            float x = array.get(i);
+            float silu = x / (1.0f +  TornadoMath.exp(-x));
+            array.set(i, silu);
+        }
+    }
+
+    public static void multiplyInPlace(FloatArray arrayA, FloatArray arrayB, int size) {
+        // Element-wise multiplication: arrayA[i] = arrayA[i] * arrayB[i]
+        for (@Parallel int i = 0; i < size; i++) {
+            float result = arrayA.get(i) * arrayB.get(i);
+            arrayA.set(i, result);
         }
     }
 }

--- a/src/main/java/com/example/tornadovm/TransformerComputeKernelsLayered.java
+++ b/src/main/java/com/example/tornadovm/TransformerComputeKernelsLayered.java
@@ -953,4 +953,19 @@ public class TransformerComputeKernelsLayered {
             arrayA.set(i, result);
         }
     }
+
+    public static void splitGateUpAndSiLU(FloatArray hb, FloatArray hbG, FloatArray hbU, int hiddenDim) {
+        // Copy and apply SiLU to gate in one pass
+        for (@Parallel int i = 0; i < hiddenDim; i++) {
+            float gateVal = hb.get(i);
+            float upVal = hb.get(hiddenDim + i);
+
+            // Apply SiLU to gate
+            float siluGate = gateVal / (1.0f + TornadoMath.exp(-gateVal));
+
+            // Store activated gate and multiply with up
+            hbG.set(i, siluGate);
+            hbU.set(i, siluGate * upVal);
+        }
+    }
 }

--- a/src/main/java/com/example/tornadovm/TransformerComputeKernelsLayered.java
+++ b/src/main/java/com/example/tornadovm/TransformerComputeKernelsLayered.java
@@ -16,22 +16,23 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Performs RMS (Root Mean Square) normalization using parallel reduction.
-     * This is the first phase of RMS normalization that computes the variance
-     * and scaling factor across all work groups.
+     * Performs RMS (Root Mean Square) normalization using parallel reduction. This is the first phase of RMS normalization that computes the variance and scaling factor across all work groups.
      *
-     * Algorithm:
-     * 1. Each thread computes square of its input element
-     * 2. Work group performs parallel reduction of squares
-     * 3. Partial sums stored per work group
-     * 4. First thread combines all partial sums and computes normalization factor
+     * Algorithm: 1. Each thread computes square of its input element 2. Work group performs parallel reduction of squares 3. Partial sums stored per work group 4. First thread combines all partial
+     * sums and computes normalization factor
      *
-     * @param context Kernel execution context
-     * @param output Array to store partial sums and final normalization factor
-     * @param x Input array to normalize
-     * @param size Number of elements to process
-     * @param ermsNorm Epsilon value squared for numerical stability
-     * @param localMemSize Size of local memory allocation (must match work group size)
+     * @param context
+     *         Kernel execution context
+     * @param output
+     *         Array to store partial sums and final normalization factor
+     * @param x
+     *         Input array to normalize
+     * @param size
+     *         Number of elements to process
+     * @param ermsNorm
+     *         Epsilon value squared for numerical stability
+     * @param localMemSize
+     *         Size of local memory allocation (must match work group size)
      */
     public static void reductionOneBlockWithLayer(KernelContext context, FloatArray output, FloatArray x, int size, float ermsNorm, int localMemSize) {
         int gid = context.globalIdx;
@@ -80,16 +81,20 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Applies the computed normalization factor to input and weight elements.
-     * This is the second phase of RMS normalization.
+     * Applies the computed normalization factor to input and weight elements. This is the second phase of RMS normalization.
      *
      * Formula: output[i] = weight[i] * (normalizationFactor * x[i])
      *
-     * @param context Kernel execution context
-     * @param output Array for normalized output
-     * @param x Input values to normalize
-     * @param weights Weight values for each element
-     * @param temp Temporary array containing normalization factor at index 0
+     * @param context
+     *         Kernel execution context
+     * @param output
+     *         Array for normalized output
+     * @param x
+     *         Input values to normalize
+     * @param weights
+     *         Weight values for each element
+     * @param temp
+     *         Temporary array containing normalization factor at index 0
      */
     public static void reductionOneBlock2WithLayer(KernelContext context, FloatArray output, FloatArray x, FloatArray weights, FloatArray temp) {
         int gid = context.globalIdx;
@@ -99,21 +104,26 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Copies keys and values into the key-value cache for attention computation.
-     * Enables efficient access to past key-value pairs during autoregressive generation.
+     * Copies keys and values into the key-value cache for attention computation. Enables efficient access to past key-value pairs during autoregressive generation.
      *
-     * Cache layout: [layer][position][dimension]
-     * - Each layer has its own key and value cache
-     * - Each position in sequence has a key and value vector
+     * Cache layout: [layer][position][dimension] - Each layer has its own key and value cache - Each position in sequence has a key and value vector
      *
-     * @param destKeyCache Destination array for key cache
-     * @param srcKey Source keys to copy
-     * @param destValueCache Destination array for value cache
-     * @param srcValue Source values to copy
-     * @param positioNlayer Array containing current position
-     * @param kvDim Dimension of key/value vectors
-     * @param layer Current transformer layer index
-     * @param contextLength Maximum sequence length
+     * @param destKeyCache
+     *         Destination array for key cache
+     * @param srcKey
+     *         Source keys to copy
+     * @param destValueCache
+     *         Destination array for value cache
+     * @param srcValue
+     *         Source values to copy
+     * @param positioNlayer
+     *         Array containing current position
+     * @param kvDim
+     *         Dimension of key/value vectors
+     * @param layer
+     *         Current transformer layer index
+     * @param contextLength
+     *         Maximum sequence length
      */
     public static void copyToCache(FloatArray destKeyCache, FloatArray srcKey, FloatArray destValueCache, FloatArray srcValue, IntArray positioNlayer, int kvDim, int layer, int contextLength) {
 
@@ -126,7 +136,6 @@ public class TransformerComputeKernelsLayered {
             destValueCache.set(destOffset + i, srcValue.get(i));
         }
     }
-
 
     public static void copyTo(FloatArray src, int srcOffset, FloatArray dest, int destOffset, int size) {
         // Generic copy: src[srcOffset:srcOffset+size] -> dest[destOffset:destOffset+size]
@@ -144,20 +153,23 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Applies Rotary Position Encoding (RoPE) to query and key vectors.
-     * RoPE rotates pairs of dimensions based on their position in the sequence,
-     * enabling the model to learn relative positional information.
+     * Applies Rotary Position Encoding (RoPE) to query and key vectors. RoPE rotates pairs of dimensions based on their position in the sequence, enabling the model to learn relative positional
+     * information.
      *
-     * For each pair of dimensions (2*i, 2*i+1):
-     * - Compute rotation angle based on position and frequency
-     * - Apply 2D rotation to the pair
+     * For each pair of dimensions (2*i, 2*i+1): - Compute rotation angle based on position and frequency - Apply 2D rotation to the pair
      *
-     * @param context Kernel execution context
-     * @param positionHolder Array containing current position
-     * @param sq Query vectors to rotate
-     * @param sk Key vectors to rotate
-     * @param kv_dim Dimension of key/value vectors
-     * @param head_size Dimension of each attention head
+     * @param context
+     *         Kernel execution context
+     * @param positionHolder
+     *         Array containing current position
+     * @param sq
+     *         Query vectors to rotate
+     * @param sk
+     *         Key vectors to rotate
+     * @param kv_dim
+     *         Dimension of key/value vectors
+     * @param head_size
+     *         Dimension of each attention head
      */
     public static void ropeRotation(KernelContext context, IntArray positionHolder, FloatArray sq, FloatArray sk, int kv_dim, int head_size) {
         int i = context.globalIdx * 2;
@@ -194,8 +206,9 @@ public class TransformerComputeKernelsLayered {
         int dimHalf = head_size / 2;
 
         // Each thread processes one dimension pair
-        if (idx >= dimHalf)
+        if (idx >= dimHalf) {
             return;
+        }
 
         int position = positionHolder.get(0);
 
@@ -209,8 +222,9 @@ public class TransformerComputeKernelsLayered {
         int totalDim = sq.getSize();
         for (int base = 0; base < totalDim; base += head_size) {
             // Skip if we're beyond the bounds
-            if (base + idx >= totalDim || base + idx + dimHalf >= totalDim)
+            if (base + idx >= totalDim || base + idx + dimHalf >= totalDim) {
                 break;
+            }
 
             // Rotate query
             float v0 = sq.get(base + idx);
@@ -719,18 +733,24 @@ public class TransformerComputeKernelsLayered {
     // @formatter:on
 
     /**
-     * Matrix-vector multiplication with residual connection.
-     * Combines regular matrix multiplication with addition of existing values.
+     * Matrix-vector multiplication with residual connection. Combines regular matrix multiplication with addition of existing values.
      *
      * Formula: hb[i] = hb[i] + w[i]·x
      *
-     * @param context Kernel execution context
-     * @param x Input vector
-     * @param hb Input/output vector (contains residual, receives result)
-     * @param w Weight matrix
-     * @param n Input dimension
-     * @param d Output dimension
-     * @param localWorkGroupSize Work group size
+     * @param context
+     *         Kernel execution context
+     * @param x
+     *         Input vector
+     * @param hb
+     *         Input/output vector (contains residual, receives result)
+     * @param w
+     *         Weight matrix
+     * @param n
+     *         Input dimension
+     * @param d
+     *         Output dimension
+     * @param localWorkGroupSize
+     *         Work group size
      */
     public static void matrixVectorGenericWithResidual(KernelContext context, FloatArray x, FloatArray hb, HalfFloatArray w, int n, int d, int localWorkGroupSize) {
         // One row per workgroup (not per thread)
@@ -753,20 +773,26 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Fused feed-forward network with SiLU activation and GLU gating.
-     * Implements the SwiGLU variant used in LLaMA-style models.
+     * Fused feed-forward network with SiLU activation and GLU gating. Implements the SwiGLU variant used in LLaMA-style models.
      *
-     * Formula: FFN(x) = SiLU(x·W1) ⊙ (x·W3)
-     * where ⊙ denotes element-wise multiplication
+     * Formula: FFN(x) = SiLU(x·W1) ⊙ (x·W3) where ⊙ denotes element-wise multiplication
      *
-     * @param context Kernel execution context
-     * @param x Input vector
-     * @param hb Output buffer
-     * @param w1 First feed-forward weight matrix
-     * @param w3 Third feed-forward weight matrix (gate)
-     * @param n Input dimension
-     * @param d Hidden dimension
-     * @param localWorkGroupSize Work group size
+     * @param context
+     *         Kernel execution context
+     * @param x
+     *         Input vector
+     * @param hb
+     *         Output buffer
+     * @param w1
+     *         First feed-forward weight matrix
+     * @param w3
+     *         Third feed-forward weight matrix (gate)
+     * @param n
+     *         Input dimension
+     * @param d
+     *         Hidden dimension
+     * @param localWorkGroupSize
+     *         Work group size
      */
     public static void fusedFeedForwardWithSiLUAndGLUActivation(KernelContext context, FloatArray x, FloatArray hb, HalfFloatArray w1, HalfFloatArray w3, int n, int d, int localWorkGroupSize) {
         // One row per workgroup (not per thread)
@@ -789,10 +815,10 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Gaussian Error Linear Unit (GELU) activation function.
-     * Approximation formula: GELU(x) ≈ 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))
+     * Gaussian Error Linear Unit (GELU) activation function. Approximation formula: GELU(x) ≈ 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))
      *
-     * @param x Input value
+     * @param x
+     *         Input value
      * @return Activated value
      */
     public static float geluActivation(float x) {
@@ -801,12 +827,12 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Sigmoid-weighted Linear Unit (SiLU) activation function.
-     * Also known as Swish activation.
+     * Sigmoid-weighted Linear Unit (SiLU) activation function. Also known as Swish activation.
      *
      * Formula: SiLU(x) = x * σ(x) = x / (1 + e^(-x))
      *
-     * @param x Input value
+     * @param x
+     *         Input value
      * @return Activated value
      */
     public static float siluActivation(float x) {
@@ -814,20 +840,20 @@ public class TransformerComputeKernelsLayered {
     }
 
     /**
-     * Optimized row-major matrix-vector multiplication for a single row.
-     * Uses parallel reduction within a work group to compute one dot product.
+     * Optimized row-major matrix-vector multiplication for a single row. Uses parallel reduction within a work group to compute one dot product.
      *
-     * Algorithm:
-     * 1. Each thread computes partial dot product
-     * 2. Partial results stored in local memory
-     * 3. Tree-based reduction combines partial results
-     * 4. Returns final dot product for the row
+     * Algorithm: 1. Each thread computes partial dot product 2. Partial results stored in local memory 3. Tree-based reduction combines partial results 4. Returns final dot product for the row
      *
-     * @param context Kernel execution context
-     * @param localSize Work group size
-     * @param x Input vector
-     * @param w Weight matrix row
-     * @param n Input dimension
+     * @param context
+     *         Kernel execution context
+     * @param localSize
+     *         Work group size
+     * @param x
+     *         Input vector
+     * @param w
+     *         Weight matrix row
+     * @param n
+     *         Input dimension
      * @return Dot product result for this row
      */
     public static float matrixVectorRowMajorOptimized(KernelContext context, int localSize, FloatArray x, FloatArray w, int n) {
@@ -915,7 +941,7 @@ public class TransformerComputeKernelsLayered {
         // SiLU activation: silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
         for (@Parallel int i = 0; i < size; i++) {
             float x = array.get(i);
-            float silu = x / (1.0f +  TornadoMath.exp(-x));
+            float silu = x / (1.0f + TornadoMath.exp(-x));
             array.set(i, silu);
         }
     }


### PR DESCRIPTION
Add support for #39

**Supported Models**
This fix enables GPU acceleration for:

- Phi-3-mini-4k-instruct
- Phi-3-mini-128k-instruct
- All Phi3 model variants in GGUF format

**how to run:**
Run Phi3 inference on CPU:

```bash
./llama-tornado --model /path/to/Phi-3-mini-4k-instruct-fp16.gguf --prompt "tell me a joke"
```

Run Phi3 inference on GPU:

```bash
./llama-tornado --gpu --model /path/to/Phi-3-mini-4k-instruct-fp16.gguf --prompt "tell me a joke" --gpu-memory 20GB
```