### PR TITLE
Add Apple Metal backend support

### DIFF
--- a/llama-tornado
+++ b/llama-tornado
@@ -19,6 +19,7 @@ from enum import Enum
 class Backend(Enum):
     OPENCL = "opencl"
     PTX = "ptx"
+    METAL = "metal"
 
 
 class LlamaRunner:
@@ -166,6 +167,14 @@ class LlamaRunner:
                     f"@{self.tornado_sdk}/etc/exportLists/ptx-exports",
                     "--add-modules",
                     "ALL-SYSTEM,jdk.incubator.vector,tornado.runtime,tornado.annotation,tornado.drivers.common,tornado.drivers.ptx",
+                ]
+            )
+        elif args.backend == Backend.METAL:
+            module_config.extend(
+                [
+                    f"@{self.tornado_sdk}/etc/exportLists/metal-exports",
+                    "--add-modules",
+                    "ALL-SYSTEM,jdk.incubator.vector,tornado.runtime,tornado.annotation,tornado.drivers.common,tornado.drivers.metal",
                 ]
             )
 
@@ -409,6 +418,13 @@ def create_parser() -> argparse.ArgumentParser:
         action="store_const",
         const=Backend.PTX,
         help="Use PTX/CUDA backend",
+    )
+    hw_group.add_argument(
+        "--metal",
+        dest="backend",
+        action="store_const",
+        const=Backend.METAL,
+        help="Use Apple Metal backend (macOS only, requires TornadoVM 4.0+)",
     )
     hw_group.add_argument("--gpu-memory", default="14GB", help="GPU memory allocation")
     hw_group.add_argument("--heap-min", default="20g", help="Minimum JVM heap size")


### PR DESCRIPTION
Add Apple Metal backend support to the `llama-tornado` launcher, enabling GPULlama3 to run on macOS with TornadoVM's native Metal driver (shipped in TornadoVM 4.0+).

**Changes (launcher only, no Java code changes):**
- Add `METAL` variant to the `Backend` enum
- Add `--metal` CLI flag for backend selection
- Configure Metal-specific module path (`tornado.drivers.metal`) and export list (`metal-exports`)

The TornadoVM API is backend-agnostic, so the Java inference code works without modification - only the launcher needed updating.

## Motivation

TornadoVM 4.0 shipped a Metal backend ([PR #796](https://github.com/beehive-lab/TornadoVM/pull/796)), but `llama-tornado` only supported `--opencl` and `--ptx`. The GPULlama3 README already notes:

> *"TornadoVM does not have a Metal backend yet [...] until we add a Metal backend to TornadoVM and start optimizing it."*

TornadoVM 4.0 has now added it - this PR enables GPULlama3 to use it 😊

## Benchmark Results

Tested on **Apple M1 Pro (macOS, ARM64)** with Llama-3.2-1B-Instruct-f16.gguf.

### LLM Inference (GPULlama3)

| Backend | TornadoVM | JDK | tok/s | Tokens | Time (s) |
|---------|-----------|-----|------:|-------:|---------:|
| OpenCL | 2.2.0 | 21 (GraalVM CE) | **6.35** | 47 | 7.40 |
| OpenCL | 3.0.0 | 25 (Temurin) | **6.87** | 47 | 6.84 |
| OpenCL | 4.0.0 | 21 (GraalVM CE) | **6.48** | 57 | 8.79 |
| **Metal** | **4.0.0** | 21 (GraalVM CE) | **0.23** | 44 | 189.85 |

### VectorAdd (10M elements)

| Backend | TornadoVM | Best (ms) | Throughput (GB/s) |
|---------|-----------|----------:|------------------:|
| OpenCL | 2.2.0 | 2.704 | 41.34 |
| OpenCL | 3.0.0 | 2.427 | 46.04 |
| OpenCL | 4.0.0 | 2.695 | 41.47 |
| **Metal** | **4.0.0** | **2.392** | **46.72** |

### Analysis

**VectorAdd**: Metal is competitive with OpenCL (~46 GB/s), slightly faster on simple parallel kernels. This matches expectations - the Metal backend handles straightforward array operations well.

**LLM inference**: Metal is ~28x slower than OpenCL (0.23 vs 6.48 tok/s). This is consistent with the known state of the Metal backend:

- [TornadoVM PR #796](https://github.com/beehive-lab/TornadoVM/pull/796) notes that MSL-specific optimizations (threadgroup memory, SIMD shuffle, async copies) are not yet implemented
- The Metal backend test pass rate does not yet match OpenCL/PTX/SPIR-V
- LLM inference involves complex control flow and frequent CPU ↔ GPU transfers - precisely the workloads where the immature Metal backend struggles