### PR TITLE
Detailed Performance Metrics (Resolves Issue #104)

### DIFF
--- a/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
+++ b/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
@@ -3,9 +3,9 @@ package org.beehive.gpullama3.auxiliary;
 /**
  * Record to store metrics from the last model run.
  * @param totalTokens The total number of tokens processed
- * @param totalSeconds The total time in seconds
+ * @param totalNanos The total time in nanoseconds
  */
-public record LastRunMetrics(int totalTokens, double totalSeconds) {
+public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
     /**
      * Singleton instance to store the latest metrics
      */
@@ -14,11 +14,11 @@ public record LastRunMetrics(int totalTokens, double totalSeconds) {
     /**
      * Sets the metrics for the latest run
      *
-     * @param tokens The total number of tokens processed
-     * @param seconds The total time in seconds
+     * @param totalTokens The total number of tokens processed
+     * @param totalNanos The total time in nanoseconds
      */
-    public static void setMetrics(int tokens, double seconds) {
-        latestMetrics = new LastRunMetrics(tokens, seconds);
+    public static void setMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
+        latestMetrics = new LastRunMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos);
     }
 
     /**
@@ -26,8 +26,11 @@ public record LastRunMetrics(int totalTokens, double totalSeconds) {
      */
     public static void printMetrics() {
         if (latestMetrics != null) {
-            double tokensPerSecond = latestMetrics.totalTokens() / latestMetrics.totalSeconds();
-            System.err.printf("\n\nachieved tok/s: %.2f. Tokens: %d, seconds: %.2f\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalSeconds());
+            double totalSeconds = latestMetrics.totalNanos() / 1_000_000_000.0;
+            double promptSeconds = latestMetrics.promptNanos() / 1_000_000_000.0;
+            double inferenceSeconds = latestMetrics.inferenceNanos() / 1_000_000_000.0;
+            double tokensPerSecond = latestMetrics.totalTokens() / totalSeconds;
+            System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s)\nPrompt tokens: %d, Prompt time: %d ns (%.2f s)\nInference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
         }
     }
 }

--- a/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
+++ b/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
@@ -16,8 +16,8 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
      * Singleton instance to store the latest metrics
      */
     private static LastRunMetrics latestMetrics;
+    // Load duration is static because it only occurs once
     private static long loadDurationNanos = 0;
-    private static boolean displayLoadDuration = true;
 
     /**
      * Sets the metrics for the latest run
@@ -46,11 +46,10 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
     public static void printMetrics() {
         if (latestMetrics != null) {
             
-            // If statement to only print metrics when they change, because they won't always change after every prompt, and it should keep things more organized.
-            if (displayLoadDuration) {
+            // If statements to only print model load once, and only print TornadoVM metrics if using GPU
+            if (loadDurationNanos > 0) {
                 double loadSeconds = loadDurationNanos / 1_000_000_000.0;
                 System.err.printf("Model load time: %d ns (%.2f s)\n", loadDurationNanos, loadSeconds);
-                displayLoadDuration = false;
             }
             if (latestMetrics.compileNanos() > 0) {
                 double compileSeconds = latestMetrics.compileNanos() / 1_000_000_000.0;
@@ -61,9 +60,8 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
                 System.err.printf("TornadoVM Warmup Time: %d ns (%.2f s)\n", latestMetrics.warmupNanos(), warmupSeconds);
             }
             
-            // Print metrics which WILL change for every prompt
             double totalSeconds = latestMetrics.totalNanos() / 1_000_000_000.0;
-            // Time to First Token = Load Time + Promt Eval time (which includes first decode step)
+            // Time to First Token = Load Time + Prompt Eval time (which includes first decode step)
             long ttftNanos = loadDurationNanos + latestMetrics.promptNanos();
             double ttftSeconds = ttftNanos / 1_000_000_000.0;
             double promptSeconds = latestMetrics.promptNanos() / 1_000_000_000.0;
@@ -73,6 +71,7 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
             double tokensPerSecond = latestMetrics.totalTokens() / totalSeconds;
             System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s), Time to first Token: %d ns (%.2f s)\nPrefill throughput: %.2f tok/s, Prompt tokens: %d, Prompt time: %d ns (%.2f s)\nDecode throughput: %.2f tok/s, Inference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, ttftNanos, ttftSeconds, prefillThroughput, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, decodeThroughput, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
             
+            loadDurationNanos = 0;
         }
     }
 }

--- a/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
+++ b/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
@@ -51,13 +51,13 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
                 double loadSeconds = loadDurationNanos / 1_000_000_000.0;
                 System.err.printf("Model load time: %d ns (%.2f s)\n", loadDurationNanos, loadSeconds);
             }
-            if (latestMetrics.compileNanos() > 0) {
-                double compileSeconds = latestMetrics.compileNanos() / 1_000_000_000.0;
-                System.err.printf("TornadoVM Compile Time: %d ns (%.2f s)\n", latestMetrics.compileNanos(), compileSeconds);
+            if (latestMetrics.tornadoCompileNanos() > 0) {
+                double compileSeconds = latestMetrics.tornadoCompileNanos() / 1_000_000_000.0;
+                System.err.printf("TornadoVM Compile Time: %d ns (%.2f s)\n", latestMetrics.tornadoCompileNanos(), compileSeconds);
             }
-            if (latestMetrics.warmupNanos() > 0) {
-                double warmupSeconds = latestMetrics.warmupNanos() / 1_000_000_000.0;
-                System.err.printf("TornadoVM Warmup Time: %d ns (%.2f s)\n", latestMetrics.warmupNanos(), warmupSeconds);
+            if (latestMetrics.tornadoWarmupNanos() > 0) {
+                double warmupSeconds = latestMetrics.tornadoWarmupNanos() / 1_000_000_000.0;
+                System.err.printf("TornadoVM Warmup Time: %d ns (%.2f s)\n", latestMetrics.tornadoWarmupNanos(), warmupSeconds);
             }
             
             double totalSeconds = latestMetrics.totalNanos() / 1_000_000_000.0;

--- a/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
+++ b/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
@@ -14,6 +14,7 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
      * Singleton instance to store the latest metrics
      */
     private static LastRunMetrics latestMetrics;
+    private static long loadDurationNanos = 0;
 
     /**
      * Sets the metrics for the latest run
@@ -27,12 +28,23 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
     public static void setMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
         latestMetrics = new LastRunMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos);
     }
+    /**
+     * @param nanos Time it takes to load the model in nanoseconds; only changes when new model is loaded
+     */
+    public static void setModelLoadDuration(long nanos){
+        loadDurationNanos = nanos;
+    }
 
     /**
      * Prints the metrics from the latest run to stderr
      */
     public static void printMetrics() {
         if (latestMetrics != null) {
+            // If statement to only print model load time once, because it will only load once when initialized.
+            if (loadDurationNanos > 0) {
+                System.err.printf("Model load time: %d ns (%.2f s)\n", loadDurationNanos, loadDurationNanos / 1_000_000_000.0);
+                loadDurationNanos = 0;
+            }
             double totalSeconds = latestMetrics.totalNanos() / 1_000_000_000.0;
             double promptSeconds = latestMetrics.promptNanos() / 1_000_000_000.0;
             double prefillThroughput = latestMetrics.promptEvalCount() / promptSeconds;
@@ -40,6 +52,7 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
             double decodeThroughput = latestMetrics.inferenceEvalCount() / inferenceSeconds;
             double tokensPerSecond = latestMetrics.totalTokens() / totalSeconds;
             System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s)\nPrefill throughput: %.2f tok/s, Prompt tokens: %d, Prompt time: %d ns (%.2f s)\nDecode throughput: %.2f tok/s, Inference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, prefillThroughput, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, decodeThroughput, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
+            
         }
     }
 }

--- a/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
+++ b/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
@@ -4,6 +4,10 @@ package org.beehive.gpullama3.auxiliary;
  * Record to store metrics from the last model run.
  * @param totalTokens The total number of tokens processed
  * @param totalNanos The total time in nanoseconds
+ * @param promptEvalCount Number of tokens in the prompt
+ * @param promptNanos Time to process the prompt in nanoseconds
+ * @param inferenceEvalCount Number of tokens in the model's response
+ * @param inferenceNanos Time to output the response in nanoseconds
  */
 public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
     /**
@@ -13,9 +17,12 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
 
     /**
      * Sets the metrics for the latest run
-     *
      * @param totalTokens The total number of tokens processed
      * @param totalNanos The total time in nanoseconds
+     * @param promptEvalCount Number of tokens in the prompt
+     * @param promptNanos Time to process the prompt in nanoseconds
+     * @param inferenceEvalCount Number of tokens in the model's response
+     * @param inferenceNanos Time to output the response in nanoseconds
      */
     public static void setMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
         latestMetrics = new LastRunMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos);
@@ -28,9 +35,11 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
         if (latestMetrics != null) {
             double totalSeconds = latestMetrics.totalNanos() / 1_000_000_000.0;
             double promptSeconds = latestMetrics.promptNanos() / 1_000_000_000.0;
+            double prefillThroughput = latestMetrics.promptEvalCount() / promptSeconds;
             double inferenceSeconds = latestMetrics.inferenceNanos() / 1_000_000_000.0;
+            double decodeThroughput = latestMetrics.inferenceEvalCount() / inferenceSeconds;
             double tokensPerSecond = latestMetrics.totalTokens() / totalSeconds;
-            System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s)\nPrompt tokens: %d, Prompt time: %d ns (%.2f s)\nInference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
+            System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s)\nPrefill throughput: %.2f tok/s, Prompt tokens: %d, Prompt time: %d ns (%.2f s)\nDecode throughput: %.2f tok/s, Inference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, prefillThroughput, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, decodeThroughput, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
         }
     }
 }

--- a/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
+++ b/src/main/java/org/beehive/gpullama3/auxiliary/LastRunMetrics.java
@@ -8,13 +8,16 @@ package org.beehive.gpullama3.auxiliary;
  * @param promptNanos Time to process the prompt in nanoseconds
  * @param inferenceEvalCount Number of tokens in the model's response
  * @param inferenceNanos Time to output the response in nanoseconds
+ * @param tornadoCompileNanos Time to compile the tornado task graph in nanoseconds
+ * @param tornadoWarmupNanos Time spent warming up until steady state in nanoseconds
  */
-public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
+public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos, long tornadoCompileNanos, long tornadoWarmupNanos) {
     /**
      * Singleton instance to store the latest metrics
      */
     private static LastRunMetrics latestMetrics;
     private static long loadDurationNanos = 0;
+    private static boolean displayLoadDuration = true;
 
     /**
      * Sets the metrics for the latest run
@@ -24,9 +27,11 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
      * @param promptNanos Time to process the prompt in nanoseconds
      * @param inferenceEvalCount Number of tokens in the model's response
      * @param inferenceNanos Time to output the response in nanoseconds
+     * @param tornadoCompileNanos Time to compile the tornado task graph in nanoseconds
+     * @param tornadoWarmupNanos Time spent warming up until steady state in nanoseconds
      */
-    public static void setMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos) {
-        latestMetrics = new LastRunMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos);
+    public static void setMetrics(int totalTokens, long totalNanos, int promptEvalCount, long promptNanos, int inferenceEvalCount, long inferenceNanos, long tornadoCompileNanos, long tornadoWarmupNanos) {
+        latestMetrics = new LastRunMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
     }
     /**
      * @param nanos Time it takes to load the model in nanoseconds; only changes when new model is loaded
@@ -40,18 +45,33 @@ public record LastRunMetrics(int totalTokens, long totalNanos, int promptEvalCou
      */
     public static void printMetrics() {
         if (latestMetrics != null) {
-            // If statement to only print model load time once, because it will only load once when initialized.
-            if (loadDurationNanos > 0) {
-                System.err.printf("Model load time: %d ns (%.2f s)\n", loadDurationNanos, loadDurationNanos / 1_000_000_000.0);
-                loadDurationNanos = 0;
+            
+            // If statement to only print metrics when they change, because they won't always change after every prompt, and it should keep things more organized.
+            if (displayLoadDuration) {
+                double loadSeconds = loadDurationNanos / 1_000_000_000.0;
+                System.err.printf("Model load time: %d ns (%.2f s)\n", loadDurationNanos, loadSeconds);
+                displayLoadDuration = false;
             }
+            if (latestMetrics.compileNanos() > 0) {
+                double compileSeconds = latestMetrics.compileNanos() / 1_000_000_000.0;
+                System.err.printf("TornadoVM Compile Time: %d ns (%.2f s)\n", latestMetrics.compileNanos(), compileSeconds);
+            }
+            if (latestMetrics.warmupNanos() > 0) {
+                double warmupSeconds = latestMetrics.warmupNanos() / 1_000_000_000.0;
+                System.err.printf("TornadoVM Warmup Time: %d ns (%.2f s)\n", latestMetrics.warmupNanos(), warmupSeconds);
+            }
+            
+            // Print metrics which WILL change for every prompt
             double totalSeconds = latestMetrics.totalNanos() / 1_000_000_000.0;
+            // Time to First Token = Load Time + Promt Eval time (which includes first decode step)
+            long ttftNanos = loadDurationNanos + latestMetrics.promptNanos();
+            double ttftSeconds = ttftNanos / 1_000_000_000.0;
             double promptSeconds = latestMetrics.promptNanos() / 1_000_000_000.0;
             double prefillThroughput = latestMetrics.promptEvalCount() / promptSeconds;
             double inferenceSeconds = latestMetrics.inferenceNanos() / 1_000_000_000.0;
             double decodeThroughput = latestMetrics.inferenceEvalCount() / inferenceSeconds;
             double tokensPerSecond = latestMetrics.totalTokens() / totalSeconds;
-            System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s)\nPrefill throughput: %.2f tok/s, Prompt tokens: %d, Prompt time: %d ns (%.2f s)\nDecode throughput: %.2f tok/s, Inference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, prefillThroughput, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, decodeThroughput, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
+            System.err.printf("\n\nAchieved tok/s: %.2f. Total tokens: %d, Total time: %d ns (%.2f s), Time to first Token: %d ns (%.2f s)\nPrefill throughput: %.2f tok/s, Prompt tokens: %d, Prompt time: %d ns (%.2f s)\nDecode throughput: %.2f tok/s, Inference tokens: %d, Inference time: %d ns (%.2f s)\n", tokensPerSecond, latestMetrics.totalTokens(), latestMetrics.totalNanos(), totalSeconds, ttftNanos, ttftSeconds, prefillThroughput, latestMetrics.promptEvalCount(), latestMetrics.promptNanos(), promptSeconds, decodeThroughput, latestMetrics.inferenceEvalCount(), latestMetrics.inferenceNanos(), inferenceSeconds);
             
         }
     }

--- a/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
+++ b/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
@@ -132,10 +132,18 @@ public final class InferenceEngine {
 
         // Calculate and print performance metrics
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }
@@ -213,10 +221,18 @@ public final class InferenceEngine {
 
         // Calculate and print performance metrics
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }
@@ -266,10 +282,18 @@ public final class InferenceEngine {
 
         // Calculate and print performance metrics
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
 
@@ -354,13 +378,30 @@ public final class InferenceEngine {
             pos++;
         }
 
-        // === Performance Metrics ===
+        // Calculate and Print Performance Metrics
         long endNanos = System.nanoTime();
-        double totalSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        // Set metrics for tokens achieved
-        LastRunMetrics.setMetrics(totalTokens, totalSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        // If statement to prevent inadvertent crashes from future features
+        if (tornadoVMMasterPlan != null) {
+            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+            // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
+            tornadoVMMasterPlan.setCompileDurationNanos(0);
+            tornadoVMMasterPlan.setWarmupDurationNanos(0
+                
+            );
+        }
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }
@@ -449,10 +490,28 @@ public final class InferenceEngine {
 
         // Calculate and print performance metrics
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        // If statement to prevent inadvertent crashes from future features
+        if (tornadoVMMasterPlan != null) {
+            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+            // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
+            tornadoVMMasterPlan.setCompileDurationNanos(0);
+            tornadoVMMasterPlan.setWarmupDurationNanos(0
+                
+            );
+        }
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }
@@ -524,10 +583,28 @@ public final class InferenceEngine {
 
         // Calculate and print performance metrics
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        // If statement to prevent inadvertent crashes from future features
+        if (tornadoVMMasterPlan != null) {
+            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+            // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
+            tornadoVMMasterPlan.setCompileDurationNanos(0);
+            tornadoVMMasterPlan.setWarmupDurationNanos(0
+                
+            );
+        }
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }
@@ -590,11 +667,20 @@ public final class InferenceEngine {
             pos++;
         }
 
+        // Calculate and Print Performance Metrics
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }
@@ -657,6 +743,7 @@ public final class InferenceEngine {
             pos++;
         }
 
+        // Calculate and Print Performance Metrics
         long endNanos = System.nanoTime();
         if (inferenceStartNanos == 0) {
             inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
@@ -675,9 +762,7 @@ public final class InferenceEngine {
             tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
             tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0
-                
-            );
+            tornadoVMMasterPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 

--- a/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
+++ b/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
@@ -667,7 +667,19 @@ public final class InferenceEngine {
         long promptNanos = inferenceStartNanos - startNanos;
         int inferenceEvalCount = generatedTokens.size();
         long inferenceNanos = endNanos - inferenceStartNanos;
-        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos);
+        long tornadoCompileNanos = 0;
+        long tornadoWarmupNanos = 0;
+        // If statement to prevent inadvertent crashes from future features
+        if (tornadoVMMasterPlan != null) {
+            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+            // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
+            tornadoVMMasterPlan.setCompileDurationNanos(0);
+            tornadoVMMasterPlan.setWarmupDurationNanos(0
+                
+            );
+        }
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
         return generatedTokens;
     }

--- a/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
+++ b/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
@@ -241,6 +241,7 @@ public final class InferenceEngine {
             IntConsumer onTokenGenerated) {
 
         long startNanos = System.nanoTime();
+        long inferenceStartNanos = 0;
         if (maxTokens < 0 || model.configuration().contextLength() < maxTokens) {
             maxTokens = model.configuration().contextLength();
         }
@@ -261,6 +262,9 @@ public final class InferenceEngine {
                     System.err.print(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
                 }
             } else {
+                if (inferenceStartNanos == 0) {
+                    inferenceStartNanos = System.nanoTime();
+                }
                 nextToken = sampler.sampleToken(state.logits);
                 if (echo) {
                     // log inferred token
@@ -397,9 +401,7 @@ public final class InferenceEngine {
             tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
             tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0
-                
-            );
+            tornadoVMMasterPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
@@ -507,9 +509,7 @@ public final class InferenceEngine {
             tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
             tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0
-                
-            );
+            tornadoVMMasterPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
@@ -600,9 +600,7 @@ public final class InferenceEngine {
             tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
             tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0
-                
-            );
+            tornadoVMMasterPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 

--- a/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
+++ b/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
@@ -658,10 +658,16 @@ public final class InferenceEngine {
         }
 
         long endNanos = System.nanoTime();
-        double totalTimeSeconds = (endNanos - startNanos) / 1_000_000_000.0;
+        if (inferenceStartNanos == 0) {
+            inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
+        }
         int totalTokens = promptIndex + generatedTokens.size();
-
-        LastRunMetrics.setMetrics(totalTokens, totalTimeSeconds);
+        long totalNanos = (endNanos - startNanos);
+        int promptEvalCount = promptIndex;
+        long promptNanos = inferenceStartNanos - startNanos;
+        int inferenceEvalCount = generatedTokens.size();
+        long inferenceNanos = endNanos - inferenceStartNanos;
+        LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos);
 
         return generatedTokens;
     }

--- a/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
+++ b/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
@@ -396,12 +396,12 @@ public final class InferenceEngine {
         long tornadoCompileNanos = 0;
         long tornadoWarmupNanos = 0;
         // If statement to prevent inadvertent crashes from future features
-        if (tornadoVMMasterPlan != null) {
-            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
-            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+        if (tornadoVMPlan != null) {
+            tornadoCompileNanos = tornadoVMPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
-            tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0);
+            tornadoVMPlan.setCompileDurationNanos(0);
+            tornadoVMPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
@@ -490,7 +490,7 @@ public final class InferenceEngine {
             state.latestToken = currentToken = nextToken;
         }
 
-        // Calculate and print performance metrics
+        // Calculate and Print Performance Metrics
         long endNanos = System.nanoTime();
         if (inferenceStartNanos == 0) {
             inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
@@ -504,12 +504,12 @@ public final class InferenceEngine {
         long tornadoCompileNanos = 0;
         long tornadoWarmupNanos = 0;
         // If statement to prevent inadvertent crashes from future features
-        if (tornadoVMMasterPlan != null) {
-            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
-            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+        if (tornadoVMPlan != null) {
+            tornadoCompileNanos = tornadoVMPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
-            tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0);
+            tornadoVMPlan.setCompileDurationNanos(0);
+            tornadoVMPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
@@ -581,7 +581,7 @@ public final class InferenceEngine {
             pos++;
         }
 
-        // Calculate and print performance metrics
+        // Calculate and Print Performance Metrics
         long endNanos = System.nanoTime();
         if (inferenceStartNanos == 0) {
             inferenceStartNanos = endNanos; // Prevents negative time if no tokens were generated
@@ -595,12 +595,12 @@ public final class InferenceEngine {
         long tornadoCompileNanos = 0;
         long tornadoWarmupNanos = 0;
         // If statement to prevent inadvertent crashes from future features
-        if (tornadoVMMasterPlan != null) {
-            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
-            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+        if (tornadoVMPlan != null) {
+            tornadoCompileNanos = tornadoVMPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
-            tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0);
+            tornadoVMPlan.setCompileDurationNanos(0);
+            tornadoVMPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 
@@ -689,7 +689,7 @@ public final class InferenceEngine {
      */
     public static List<Integer> generateTokensGPUGranite(Model model, State state, int startPosition,
             List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
-            IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMMasterPlan) {
+            IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
         long startNanos = System.nanoTime();
         long inferenceStartNanos = 0;
 
@@ -707,7 +707,7 @@ public final class InferenceEngine {
 
         while (pos < maxTokens) {
             // Call TornadoVM forward pass (same as Llama for now)
-            logits = InferenceCore.forwardTornadoVM(model, state, currentToken, pos, tornadoVMMasterPlan);
+            logits = InferenceCore.forwardTornadoVM(model, state, currentToken, pos, tornadoVMPlan);
 
             if (promptIndex < promptTokens.size()) {
                 nextToken = promptTokens.get(promptIndex++);
@@ -755,12 +755,12 @@ public final class InferenceEngine {
         long tornadoCompileNanos = 0;
         long tornadoWarmupNanos = 0;
         // If statement to prevent inadvertent crashes from future features
-        if (tornadoVMMasterPlan != null) {
-            tornadoCompileNanos = tornadoVMMasterPlan.getCompileDurationNanos();
-            tornadoWarmupNanos = tornadoVMMasterPlan.getWarmupDurationNanos();
+        if (tornadoVMPlan != null) {
+            tornadoCompileNanos = tornadoVMPlan.getCompileDurationNanos();
+            tornadoWarmupNanos = tornadoVMPlan.getWarmupDurationNanos();
             // Reset values so they are only output if they are changed in tornadoVMMasterPlan.java
-            tornadoVMMasterPlan.setCompileDurationNanos(0);
-            tornadoVMMasterPlan.setWarmupDurationNanos(0);
+            tornadoVMPlan.setCompileDurationNanos(0);
+            tornadoVMPlan.setWarmupDurationNanos(0);
         }
         LastRunMetrics.setMetrics(totalTokens, totalNanos, promptEvalCount, promptNanos, inferenceEvalCount, inferenceNanos, tornadoCompileNanos, tornadoWarmupNanos);
 

--- a/src/main/java/org/beehive/gpullama3/model/loader/ModelLoader.java
+++ b/src/main/java/org/beehive/gpullama3/model/loader/ModelLoader.java
@@ -85,6 +85,9 @@ public abstract class ModelLoader {
      * @throws IllegalStateException if AOT loading is enabled but the preloaded model is unavailable
      */
     public static Model loadModel(Options options) throws IOException {
+        //Keep track of load time for performance metrics
+        long startLoadNanos = System.nanoTime();
+
         Path ggufPath = options.modelPath();
         int contextLength = options.maxTokens();
         boolean useTornadovm = options.useTornadovm();
@@ -94,19 +97,36 @@ public abstract class ModelLoader {
         // detect model type
         ModelType modelType = detectModelType(gguf.getMetadata());
         // model type-specific load
-        return modelType.loadModel(gguf.getFileChannel(), gguf, contextLength, useTornadovm);
+        Model loadedModel = modelType.loadModel(gguf.getFileChannel(), gguf, contextLength, useTornadovm);
+
+        //Calculate load time and send to LastRunMetrics
+        long endLoadNanos = System.nanoTime();
+        long loadNanos = (endLoadNanos - startLoadNanos);
+        LastRunMetrics.setModelLoadDuration(loadNanos);
+
+        return loadedModel;
     }
 
     /**
      * For compatibility with langchain4j and quarkus.
      */
     public static Model loadModel(Path ggufPath, int contextLength, boolean loadWeights, boolean useTornadovm) throws IOException {
+        //Keep track of load time for performance metrics
+        long startLoadNanos = System.nanoTime();
+        
         // initial load of metadata from gguf file
         GGUF gguf = GGUF.loadGGUFMetadata(ggufPath);
         // detect model type
         ModelType modelType = detectModelType(gguf.getMetadata());
         // model type-specific load
-        return modelType.loadModel(gguf.getFileChannel(), gguf, contextLength, useTornadovm);
+        Model loadedModel = modelType.loadModel(gguf.getFileChannel(), gguf, contextLength, useTornadovm);
+
+        //Calculate load time and send to LastRunMetrics
+        long endLoadNanos = System.nanoTime();
+        long loadNanos = (endLoadNanos - startLoadNanos);
+        LastRunMetrics.setModelLoadDuration(loadNanos);
+
+        return loadedModel;
     }
 
     /**

--- a/src/main/java/org/beehive/gpullama3/model/loader/ModelLoader.java
+++ b/src/main/java/org/beehive/gpullama3/model/loader/ModelLoader.java
@@ -11,6 +11,7 @@ import org.beehive.gpullama3.tensor.tornado.FP16TornadoTensor;
 import org.beehive.gpullama3.tensor.tornado.FP32TornadoTensor;
 import org.beehive.gpullama3.tensor.tornado.Q8_0TornadoTensor;
 import org.beehive.gpullama3.tensor.tornado.TornadoTensor;
+import org.beehive.gpullama3.auxiliary.LastRunMetrics;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.*;
 

--- a/src/main/java/org/beehive/gpullama3/tornadovm/TornadoVMMasterPlan.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/TornadoVMMasterPlan.java
@@ -54,7 +54,7 @@ public class TornadoVMMasterPlan {
      * @return The initialized TornadoVMMasterPlan ready for inference
      */
     public static TornadoVMMasterPlan initializeTornadoVMPlan(State state, Model model) {
-        // Record Start Time for Performance stats
+        // Record Start Time for Performance metrics
         long startTime = System.nanoTime();
 
         // Start a timing message if enabled

--- a/src/main/java/org/beehive/gpullama3/tornadovm/TornadoVMMasterPlan.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/TornadoVMMasterPlan.java
@@ -17,6 +17,24 @@ public class TornadoVMMasterPlan {
     private final Configuration config;
     public TornadoExecutionPlan executionPlan;
     GenericLayerPlanner tornadoVMLayerPlanner;
+    
+    // Performance variables and their corresponding methods to be accessed from LastRunMetrics
+    private long compileDurationNanos = 0;
+    private long warmupDurationNanos = 0;
+
+    public long getCompileDurationNanos() {
+        return compileDurationNanos;
+    }
+    public void setCompileDurationNanos(long nanos) {
+        this.compileDurationNanos = nanos;
+    }
+
+    public long getWarmupDurationNanos() {
+        return warmupDurationNanos;
+    }
+    public void setWarmupDurationNanos(long nanos) {
+        this.warmupDurationNanos = nanos;
+    }
 
     public TornadoVMMasterPlan(State state, Model model) {
         this.tornadoVMLayerPlanner = createPlanner(state, model);
@@ -36,10 +54,8 @@ public class TornadoVMMasterPlan {
      * @return The initialized TornadoVMMasterPlan ready for inference
      */
     public static TornadoVMMasterPlan initializeTornadoVMPlan(State state, Model model) {
-        // Initialize timing variables outside conditional blocks to avoid scope issues
+        // Record Start Time for Performance stats
         long startTime = System.nanoTime();
-        long planCreationTime = 0;
-        long warmupTime = 0;
 
         // Start a timing message if enabled
         if (ENABLE_TORNADOVM_INIT_TIME) {
@@ -49,27 +65,34 @@ public class TornadoVMMasterPlan {
         // 1. Pre-allocate the TornadoVM plan
         TornadoVMMasterPlan tornadoVMPlan = new TornadoVMMasterPlan(state, model);
 
+        // Calculate and Set Compile Time
+        long planCreationTime = System.nanoTime();
+        tornadoVMPlan.setCompileDurationNanos(planCreationTime - startTime);
+
         // Record time after plan creation
         if (ENABLE_TORNADOVM_INIT_TIME) {
-            planCreationTime = System.nanoTime();
             System.err.printf("TornadoVM GPU execution plan creation: %.2f ms\n", (planCreationTime - startTime) / 1_000_000.0);
         }
 
         // 2. Perform warmup with extra iterations to ensure JIT compilation is complete
         tornadoVMPlan.executionPlan.withPreCompilation(); // Force JIT compilation from Java to GPU code
 
+        long warmupTime = System.nanoTime();
+
         // Record time after warmup
         if (ENABLE_TORNADOVM_INIT_TIME) {
-            warmupTime = System.nanoTime();
             System.err.printf("Java to GPU JIT compiler warmup: %.2f ms\n", (warmupTime - planCreationTime) / 1_000_000.0);
         }
 
         // 3. Perform copy-in of read-only weights and objects
         tornadoVMPlan.forceCopyInReadOnlyDataLayered(); // Force copy-in read-only weights
+        
+        // Calculate and Set Total Warmup Time
+        long copyTime = System.nanoTime();
+        tornadoVMPlan.setWarmupDurationNanos(copyTime - planCreationTime);
 
         // Record final timing information
         if (ENABLE_TORNADOVM_INIT_TIME) {
-            long copyTime = System.nanoTime();
             System.err.printf("Transfer read-only weights to GPU: %.2f ms\n", (copyTime - warmupTime) / 1_000_000.0);
             System.err.printf("Finished TornadoVM initialization...\n \n");
         }


### PR DESCRIPTION
Resolves #104 

Added functionality to keep track of the fine-grained performance metrics described in Issue #104.

In LastRunMetrics:

- Modified the record to accept all necessary variables (except for model load duration) as parameters and updated the record's documentation accordingly.
- Added a static long for load duration, because it will not change between every print. Also added a method for setting the load duration to be called from ModelLoader.
- Modified the existing print statement to print new parameters, and print durations in both nanoseconds and seconds. Also created if statements to print the model load duration only once, and the TornadoVM metrics only when using the GPU.

In InferenceEngine:

- Sent new metric information to the setMetrics method in LastRunMetrics
- TornadoVM metrics are retrieved from TornadoVMMasterPlan when using GPU, otherwise they are set to 0, so they are not printed.
- Model load time is NOT retrieved here; the load duration is sent to LastRunMetrics from ModelLoader because it does not need to be retrieved after every response.
- Added a timer for inference start in CPU Phi3, which was previously missing
- Changed the name of the TornadoVMMasterPlan object in the GPU Granite method to be consistent with the naming of all other TornadoVMMasterPlan objects in InferenceEngine.

In ModelLoader:

- Added simple model duration timers and logic; times sent to LastRunMetrics
- Declared a new model instead of returning the result of modelType.loadModel immediately to time the loading duration properly.

In TornadoVMMasterPlan:

- Added variables to keep track of compile and warmup duration, as well as corresponding accessor and mutator methods. The accessor methods are called from InferenceEngine and passed to the setMetrics method in LastRunMetrics. The mutators are called when times are calculated within TornadaVMMasterPlan. 
- Timing variables were already in place, but only written to when using a flag for debugging. They are now always written to, and the if statements for the flags are still there, and will still print the same information if the flag is used.

One last note not related to the changes:
In the contributing instructions, contributors are instructed to PR the "develop" branch. It appears the branch no longer exists, and the instructions are outdated. Might be confusing for new contributors.