### PR TITLE
Update TornadoVM dependency for jdk21 and fixed suffix regarding future releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <properties>
             <!-- CI-friendly version: resolved by flatten-maven-plugin at build time -->
             <revision>0.4.0</revision>
-            <tornadovm.base.version>4.0.0</tornadovm.base.version>              <!-- TornadoVM base version (without jdk suffix) -->
+            <tornadovm.base.version>4.0.1</tornadovm.base.version>              <!-- TornadoVM base version (without jdk suffix) -->
             <jdk.version.suffix></jdk.version.suffix>                           <!-- JDK Suffix: empty=JDK21, -jdk25=JDK25 -->
             <tornadovm.version>${tornadovm.base.version}</tornadovm.version>    <!-- Default: JDK21 (no suffix) -->
             <!-- Compiler defaults (overridden by JDK profiles below) -->
@@ -146,8 +146,8 @@
                 <properties>
                     <maven.compiler.source>21</maven.compiler.source>
                     <maven.compiler.target>21</maven.compiler.target>
-                    <!-- JDK21 default - no jdk suffix needed -->
-                    <tornadovm.version>${tornadovm.base.version}</tornadovm.version>
+                    <jdk.version.suffix>-jdk21</jdk.version.suffix>
+                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
                 </properties>
                 <build>
                     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
         <properties>
             <!-- CI-friendly version: resolved by flatten-maven-plugin at build time -->
             <revision>0.4.0</revision>
-            <tornadovm.base.version>4.0.1</tornadovm.base.version>              <!-- TornadoVM base version (without jdk suffix) -->
-            <jdk.version.suffix></jdk.version.suffix>                           <!-- JDK Suffix: empty=JDK21, -jdk25=JDK25 -->
-            <tornadovm.version>${tornadovm.base.version}</tornadovm.version>    <!-- Default: JDK21 (no suffix) -->
+            <tornadovm.base.version>4.0.1</tornadovm.base.version>
+            <jdk.version.suffix>-jdk21</jdk.version.suffix>
+            <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
             <!-- Compiler defaults (overridden by JDK profiles below) -->
             <maven.compiler.source>25</maven.compiler.source>
             <maven.compiler.target>25</maven.compiler.target>


### PR DESCRIPTION
This PR udpates the `pom` file to use the latest TornadoVM release (4.0.1-jdk21 and 4.0.1-jdk25) which contain the fix for the F16 models.

A more detailed analysis regarding the fixes is available in this issue: [828](https://github.com/beehive-lab/TornadoVM/issues/828) and these PRs: [829](https://github.com/beehive-lab/TornadoVM/pull/829) [830](https://github.com/beehive-lab/TornadoVM/pull/830) [831](https://github.com/beehive-lab/TornadoVM/pull/831).

**Note:** Starting from TornadoVM 4.0.1 and onwards, the jdk21 versions will include the suffix `jdk21` to be consistent with the `jdk25` versions.


You can use TornadoVM with SDKMAN! on macOS or Linux for the JDK version you want (e.g. jdk25), as follows:

- Use the new TornadoVM SDK version:
```bash
sdk install tornadovm 4.0.1-jdk25-opencl
```

or

```bash
sdk install tornadovm 4.0.1-jdk25-metal
```

- Build GPULlama3.java:
```bash
make
```

- Run an example:
```bash
./llama-tornado --gpu --verbose-init --metal --model /opt/models/Llama-3.2-1B-Instruct-F16.gguf --prompt "tell me a joke" --gpu-memory 30GB
```