### PR TITLE
Add prefill-decode and batch-prefill-decode for Qwen3 (FP16 and Q8_0)

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -187,6 +187,53 @@ jobs:
           configuration: standard
           metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-4b-f16-standard.json
 
+      - name: FP16 - Run Qwen3-4B-f16.gguf - Prefill-Decode
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-4B-f16.gguf
+          model: Qwen3-4B
+          quantization: F16
+          configuration: prefill-decode
+          flags: --with-prefill-decode
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-4b-f16-prefill-decode.json
+
+      - name: FP16 - Run Qwen3-4B-f16.gguf - Batch-Prefill-Decode
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-4B-f16.gguf
+          model: Qwen3-4B
+          quantization: F16
+          configuration: batch-prefill-decode
+          flags: --with-prefill-decode --batch-prefill-size 32
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-4b-f16-batch-prefill-decode.json
+
+      # PTX-only: CUDA-graph variants
+      - name: PTX - FP16 - Run Qwen3-4B-f16.gguf - Prefill-Decode-CUDA-Graphs
+        if: matrix.backend.name == 'ptx'
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-4B-f16.gguf
+          model: Qwen3-4B
+          quantization: F16
+          configuration: prefill-decode-cuda-graphs
+          flags: --with-prefill-decode --cuda-graphs
+          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-4b-f16-prefill-decode-cuda-graphs.json
+
+      - name: PTX - FP16 - Run Qwen3-4B-f16.gguf - Batch-Prefill-Decode-CUDA-Graphs
+        if: matrix.backend.name == 'ptx'
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-4B-f16.gguf
+          model: Qwen3-4B
+          quantization: F16
+          configuration: batch-prefill-decode-cuda-graphs
+          flags: --with-prefill-decode --batch-prefill-size 32 --cuda-graphs
+          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-4b-f16-batch-prefill-decode-cuda-graphs.json
+
       - name: FP16 - Run Mistral-7B-Instruct-v0.3.fp16.gguf
         uses: ./.github/actions/run-inference
         with:
@@ -357,6 +404,53 @@ jobs:
           quantization: Q8_0
           configuration: standard
           metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-0-6b-q8-standard.json
+
+      - name: Q8 - Run Qwen3-0.6B-Q8_0.gguf - Prefill-Decode
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-0.6B-Q8_0.gguf
+          model: Qwen3-0.6B
+          quantization: Q8_0
+          configuration: prefill-decode
+          flags: --with-prefill-decode
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-0-6b-q8-prefill-decode.json
+
+      - name: Q8 - Run Qwen3-0.6B-Q8_0.gguf - Batch-Prefill-Decode
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-0.6B-Q8_0.gguf
+          model: Qwen3-0.6B
+          quantization: Q8_0
+          configuration: batch-prefill-decode
+          flags: --with-prefill-decode --batch-prefill-size 32
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-0-6b-q8-batch-prefill-decode.json
+
+      # PTX-only: CUDA-graph variants
+      - name: PTX - Q8 - Run Qwen3-0.6B-Q8_0.gguf - Prefill-Decode-CUDA-Graphs
+        if: matrix.backend.name == 'ptx'
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-0.6B-Q8_0.gguf
+          model: Qwen3-0.6B
+          quantization: Q8_0
+          configuration: prefill-decode-cuda-graphs
+          flags: --with-prefill-decode --cuda-graphs
+          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-0-6b-q8-prefill-decode-cuda-graphs.json
+
+      - name: PTX - Q8 - Run Qwen3-0.6B-Q8_0.gguf - Batch-Prefill-Decode-CUDA-Graphs
+        if: matrix.backend.name == 'ptx'
+        uses: ./.github/actions/run-inference
+        with:
+          backend: ${{ matrix.backend.name }}
+          model_file: Qwen3-0.6B-Q8_0.gguf
+          model: Qwen3-0.6B
+          quantization: Q8_0
+          configuration: batch-prefill-decode-cuda-graphs
+          flags: --with-prefill-decode --batch-prefill-size 32 --cuda-graphs
+          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-0-6b-q8-batch-prefill-decode-cuda-graphs.json
 
       - name: Q8 - Run Phi-3-mini-4k-instruct-Q8_0.gguf
         uses: ./.github/actions/run-inference

--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -177,62 +177,62 @@ jobs:
           flags: --with-prefill-decode --batch-prefill-size 32 --cuda-graphs
           metrics_file: ${{ runner.temp }}/metrics-ptx-llama-1b-f16-batch-prefill-decode-cuda-graphs.json
 
-      - name: FP16 - Run Qwen3-4B-f16.gguf
+      - name: FP16 - Run Qwen3-0.6B-f16.gguf
         uses: ./.github/actions/run-inference
         with:
           backend: ${{ matrix.backend.name }}
-          model_file: Qwen3-4B-f16.gguf
-          model: Qwen3-4B
+          model_file: Qwen3-0.6B-f16.gguf
+          model: Qwen3-0.6B
           quantization: F16
           configuration: standard
-          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-4b-f16-standard.json
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-0.6b-f16-standard.json
 
-      - name: FP16 - Run Qwen3-4B-f16.gguf - Prefill-Decode
+      - name: FP16 - Run Qwen3-0.6B-f16.gguf - Prefill-Decode
         uses: ./.github/actions/run-inference
         with:
           backend: ${{ matrix.backend.name }}
-          model_file: Qwen3-4B-f16.gguf
-          model: Qwen3-4B
+          model_file: Qwen3-0.6B-f16.gguf
+          model: Qwen3-0.6B
           quantization: F16
           configuration: prefill-decode
           flags: --with-prefill-decode
-          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-4b-f16-prefill-decode.json
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-0.6b-f16-prefill-decode.json
 
-      - name: FP16 - Run Qwen3-4B-f16.gguf - Batch-Prefill-Decode
+      - name: FP16 - Run Qwen3-0.6B-f16.gguf - Batch-Prefill-Decode
         uses: ./.github/actions/run-inference
         with:
           backend: ${{ matrix.backend.name }}
-          model_file: Qwen3-4B-f16.gguf
-          model: Qwen3-4B
+          model_file: Qwen3-0.6B-f16.gguf
+          model: Qwen3-0.6B
           quantization: F16
           configuration: batch-prefill-decode
           flags: --with-prefill-decode --batch-prefill-size 32
-          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-4b-f16-batch-prefill-decode.json
+          metrics_file: ${{ runner.temp }}/metrics-${{ matrix.backend.name }}-qwen3-0.6b-f16-batch-prefill-decode.json
 
       # PTX-only: CUDA-graph variants
-      - name: PTX - FP16 - Run Qwen3-4B-f16.gguf - Prefill-Decode-CUDA-Graphs
+      - name: PTX - FP16 - Run Qwen3-0.6B-f16.gguf - Prefill-Decode-CUDA-Graphs
         if: matrix.backend.name == 'ptx'
         uses: ./.github/actions/run-inference
         with:
           backend: ${{ matrix.backend.name }}
-          model_file: Qwen3-4B-f16.gguf
-          model: Qwen3-4B
+          model_file: Qwen3-0.6B-f16.gguf
+          model: Qwen3-0.6B
           quantization: F16
           configuration: prefill-decode-cuda-graphs
           flags: --with-prefill-decode --cuda-graphs
-          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-4b-f16-prefill-decode-cuda-graphs.json
+          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-0.6b-f16-prefill-decode-cuda-graphs.json
 
-      - name: PTX - FP16 - Run Qwen3-4B-f16.gguf - Batch-Prefill-Decode-CUDA-Graphs
+      - name: PTX - FP16 - Run Qwen3-0.6B-f16.gguf - Batch-Prefill-Decode-CUDA-Graphs
         if: matrix.backend.name == 'ptx'
         uses: ./.github/actions/run-inference
         with:
           backend: ${{ matrix.backend.name }}
-          model_file: Qwen3-4B-f16.gguf
-          model: Qwen3-4B
+          model_file: Qwen3-0.6B-f16.gguf
+          model: Qwen3-0.6B
           quantization: F16
           configuration: batch-prefill-decode-cuda-graphs
           flags: --with-prefill-decode --batch-prefill-size 32 --cuda-graphs
-          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-4b-f16-batch-prefill-decode-cuda-graphs.json
+          metrics_file: ${{ runner.temp }}/metrics-ptx-qwen3-0.6b-f16-batch-prefill-decode-cuda-graphs.json
 
       - name: FP16 - Run Mistral-7B-Instruct-v0.3.fp16.gguf
         uses: ./.github/actions/run-inference

--- a/src/main/java/org/beehive/gpullama3/inference/state/Qwen3State.java
+++ b/src/main/java/org/beehive/gpullama3/inference/state/Qwen3State.java
@@ -36,6 +36,18 @@ public final class Qwen3State extends State {
     }
 
     @Override
+    protected int batchQDim(Configuration config) {
+        Qwen3Configuration q3 = (Qwen3Configuration) config;
+        return q3.numberOfHeadsKey() * q3.numberOfHeads();
+    }
+
+    @Override
+    protected int batchKvDim(Configuration config) {
+        Qwen3Configuration q3 = (Qwen3Configuration) config;
+        return q3.numberOfHeadsValue() * q3.numberOfKeyValueHeads();
+    }
+
+    @Override
     protected StateFields createStateFields(Configuration configuration) {
         StateFields fields = new StateFields();
 

--- a/src/main/java/org/beehive/gpullama3/inference/state/State.java
+++ b/src/main/java/org/beehive/gpullama3/inference/state/State.java
@@ -77,10 +77,10 @@ public abstract class State {
     public final HalfFloatArray embeddingXBatch;    // B × dim  (FP16 input)
     public final FloatArray wrapXBatch;             // B × dim  (live activations / Q8_0 dequant)
     public final HalfFloatArray wrapXbFP16Batch;    // B × dim  (RMSNorm output, FP16)
-    public final FloatArray wrapQBatch;             // B × dim
+    public final FloatArray wrapQBatch;             // B × qDim (Q projection)
     public final FloatArray wrapKBatch;             // B × kvDim
     public final FloatArray wrapVBatch;             // B × kvDim
-    public final FloatArray wrapXbBatch;            // B × dim  (attention output)
+    public final FloatArray wrapXbBatch;            // B × qDim  (attention output)
     public final FloatArray wrapHbBatch;            // B × hiddenDim
     public final FloatArray attnScaleBatch;         // B        (per-token RMS scale, attn)
     public final FloatArray ffnScaleBatch;          // B        (per-token RMS scale, FFN)
@@ -135,14 +135,15 @@ public abstract class State {
 
         int gpuBatchSize = Integer.getInteger("llama.prefillBatchSize", 1);
         if (gpuBatchSize > 1) {
-            int kvDim = (config.dim() * config.numberOfKeyValueHeads()) / config.numberOfHeads();
+            int qDim  = batchQDim(config);
+            int kvDim = batchKvDim(config);
             this.embeddingXBatch = new HalfFloatArray(gpuBatchSize * config.dim());
             this.wrapXBatch = new FloatArray(gpuBatchSize * config.dim());
             this.wrapXbFP16Batch = new HalfFloatArray(gpuBatchSize * config.dim());
-            this.wrapQBatch = new FloatArray(gpuBatchSize * config.dim());
+            this.wrapQBatch = new FloatArray(gpuBatchSize * qDim);
             this.wrapKBatch = new FloatArray(gpuBatchSize * kvDim);
             this.wrapVBatch = new FloatArray(gpuBatchSize * kvDim);
-            this.wrapXbBatch = new FloatArray(gpuBatchSize * config.dim());
+            this.wrapXbBatch = new FloatArray(gpuBatchSize * qDim);
             this.wrapHbBatch = new FloatArray(gpuBatchSize * config.hiddenDim());
             this.attnScaleBatch = new FloatArray(gpuBatchSize);
             this.ffnScaleBatch = new FloatArray(gpuBatchSize);
@@ -160,6 +161,16 @@ public abstract class State {
             this.ffnScaleBatch = null;
             this.batchStartPosHolder = null;
         }
+    }
+
+    /** Q-projection output dimension per token (model specific: = dim for Llama; differs for Qwen3). */
+    protected int batchQDim(Configuration config) {
+        return config.dim();
+    }
+
+    /** KV-cache dimension per token (model specific: = dim*nHeadKv/nHeads for Llama; differs for Qwen3). */
+    protected int batchKvDim(Configuration config) {
+        return (config.dim() * config.numberOfKeyValueHeads()) / config.numberOfHeads();
     }
 
     // Abstract method - subclasses implement their specific allocation logic and sizes

--- a/src/main/java/org/beehive/gpullama3/model/qwen3/Qwen3.java
+++ b/src/main/java/org/beehive/gpullama3/model/qwen3/Qwen3.java
@@ -2,6 +2,8 @@ package org.beehive.gpullama3.model.qwen3;
 
 import org.beehive.gpullama3.inference.InferenceCore;
 import org.beehive.gpullama3.inference.InferenceEngine;
+import org.beehive.gpullama3.inference.InferenceEngineWithBatchPrefillDecode;
+import org.beehive.gpullama3.inference.InferenceEngineWithPrefillDecode;
 import org.beehive.gpullama3.inference.sampler.Sampler;
 import org.beehive.gpullama3.inference.state.Qwen3State;
 import org.beehive.gpullama3.inference.state.State;
@@ -88,10 +90,10 @@ public class Qwen3 extends AbstractModel {
     public List<Integer> generateTokensGPU(State state, int startPosition, List<Integer> promptTokens, Set<Integer> stopTokens, int maxTokens, Sampler sampler, boolean echo,
             IntConsumer onTokenGenerated, TornadoVMMasterPlan tornadoVMPlan) {
         if (WITH_PREFILL_DECODE && TornadoVMMasterPlan.PREFILL_BATCH_SIZE > 1) {
-            throw new UnsupportedOperationException("Batch prefill/decode on GPU not yet implemented for Qwen3");
+            return InferenceEngineWithBatchPrefillDecode.generateTokensGPULlama(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated, tornadoVMPlan);
         }
         if (WITH_PREFILL_DECODE) {
-            throw new UnsupportedOperationException("Prefill/decode on GPU not yet implemented for Qwen3");
+            return InferenceEngineWithPrefillDecode.generateTokensGPULlama(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated, tornadoVMPlan);
         }
         return InferenceEngine.generateTokensGPUQwen3(this, state, startPosition, promptTokens, stopTokens, maxTokens, sampler, echo, onTokenGenerated, tornadoVMPlan);
     }

--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/Qwen3Kernels.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/Qwen3Kernels.java
@@ -894,5 +894,325 @@ public class Qwen3Kernels {
             }
         }
     }
+
+    // ── Batch prefill kernels ────────────────────────────────────────────────
+
+    /**
+     * Batched fused Q/K/V projection for Qwen3 GQA (FP16 weights, FP16 input).
+     *
+     * <p>Like {@code TransformerBatchPrefillKernels.batchedFusedQKVMatmul} but uses
+     * separate {@code qDim} (Q output rows) and {@code kvDim} (K/V output rows).
+     * Row layout: [0, qDim) → Q; [qDim, qDim+kvDim) → K; [qDim+kvDim, qDim+2*kvDim) → V.
+     * Q output stride per batch = qDim; K/V output stride = kvDim.</p>
+     *
+     * Worker: B*(qDim+2*kvDim) workgroups × localWorkGroupSize threads.
+     */
+    public static void batchedFusedQKVMatmulFP16(
+            KernelContext context,
+            HalfFloatArray xbFP16Batch,
+            FloatArray wrapQBatch,
+            FloatArray wrapKBatch,
+            FloatArray wrapVBatch,
+            HalfFloatArray wq,
+            HalfFloatArray wk,
+            HalfFloatArray wv,
+            int inputDim,
+            int qDim,
+            int kvDim,
+            int localWorkGroupSize) {
+
+        int groupId = context.globalIdx / localWorkGroupSize;
+        int localId = context.localIdx;
+        int totalRows = qDim + 2 * kvDim;
+        int batchIdx = groupId / totalRows;
+        int rowIdx = groupId % totalRows;
+        int inputOff = batchIdx * inputDim;
+
+        float[] localSum = context.allocateFloatLocalArray(localWorkGroupSize);
+
+        if (rowIdx < qDim) {
+            int rowOff = rowIdx * inputDim;
+            float partial = 0.0f;
+            for (int j = localId; j < inputDim; j += localWorkGroupSize) {
+                partial += wq.get(rowOff + j).getFloat32() * xbFP16Batch.get(inputOff + j).getFloat32();
+            }
+            localSum[localId] = partial;
+            context.localBarrier();
+            for (int s = localWorkGroupSize / 2; s > 0; s >>= 1) {
+                if (localId < s) localSum[localId] += localSum[localId + s];
+                context.localBarrier();
+            }
+            if (localId == 0) wrapQBatch.set(batchIdx * qDim + rowIdx, localSum[0]);
+
+        } else if (rowIdx < qDim + kvDim) {
+            int kRow = rowIdx - qDim;
+            int rowOff = kRow * inputDim;
+            float partial = 0.0f;
+            for (int j = localId; j < inputDim; j += localWorkGroupSize) {
+                partial += wk.get(rowOff + j).getFloat32() * xbFP16Batch.get(inputOff + j).getFloat32();
+            }
+            localSum[localId] = partial;
+            context.localBarrier();
+            for (int s = localWorkGroupSize / 2; s > 0; s >>= 1) {
+                if (localId < s) localSum[localId] += localSum[localId + s];
+                context.localBarrier();
+            }
+            if (localId == 0) wrapKBatch.set(batchIdx * kvDim + kRow, localSum[0]);
+
+        } else {
+            int vRow = rowIdx - qDim - kvDim;
+            int rowOff = vRow * inputDim;
+            float partial = 0.0f;
+            for (int j = localId; j < inputDim; j += localWorkGroupSize) {
+                partial += wv.get(rowOff + j).getFloat32() * xbFP16Batch.get(inputOff + j).getFloat32();
+            }
+            localSum[localId] = partial;
+            context.localBarrier();
+            for (int s = localWorkGroupSize / 2; s > 0; s >>= 1) {
+                if (localId < s) localSum[localId] += localSum[localId + s];
+                context.localBarrier();
+            }
+            if (localId == 0) wrapVBatch.set(batchIdx * kvDim + vRow, localSum[0]);
+        }
+    }
+
+    /**
+     * Batched fused Q/K/V projection for Qwen3 GQA (Q8_0 weights, FP32 input).
+     *
+     * Worker: B*(qDim+2*kvDim) workgroups × localWorkGroupSize threads.
+     */
+    public static void batchedFusedQKVMatmulQ8_0(
+            KernelContext context,
+            FloatArray wrapXbBatch,
+            FloatArray wrapQBatch,
+            FloatArray wrapKBatch,
+            FloatArray wrapVBatch,
+            ByteArray wq,
+            ByteArray wk,
+            ByteArray wv,
+            int inputDim,
+            int qDim,
+            int kvDim,
+            int localWorkGroupSize) {
+
+        int groupId = context.globalIdx / localWorkGroupSize;
+        int localId = context.localIdx;
+        int totalRows = qDim + 2 * kvDim;
+        int batchIdx = groupId / totalRows;
+        int rowIdx = groupId % totalRows;
+        int inputOff = batchIdx * inputDim;
+
+        final int blockSize = 32;
+        final int Q8_0_BLOCK_BYTES = 34;
+
+        float[] localSum = context.allocateFloatLocalArray(localWorkGroupSize);
+
+        if (rowIdx < qDim) {
+            int blocksPerRow = (inputDim + blockSize - 1) / blockSize;
+            int rowBlockOff = rowIdx * blocksPerRow;
+            float partial = 0.0f;
+            for (int j = localId; j < inputDim; j += localWorkGroupSize) {
+                int blockIdx = j / blockSize;
+                int withinBlock = j % blockSize;
+                int blockByteOff = (rowBlockOff + blockIdx) * Q8_0_BLOCK_BYTES;
+                HalfFloat sc = wq.getHalfFloat(blockByteOff);
+                byte q8 = wq.get(blockByteOff + 2 + withinBlock);
+                partial += ((float) q8 * sc.getFloat32()) * wrapXbBatch.get(inputOff + j);
+            }
+            localSum[localId] = partial;
+            context.localBarrier();
+            for (int s = localWorkGroupSize / 2; s > 0; s >>= 1) {
+                if (localId < s) localSum[localId] += localSum[localId + s];
+                context.localBarrier();
+            }
+            if (localId == 0) wrapQBatch.set(batchIdx * qDim + rowIdx, localSum[0]);
+
+        } else if (rowIdx < qDim + kvDim) {
+            int kRow = rowIdx - qDim;
+            int blocksPerRow = (inputDim + blockSize - 1) / blockSize;
+            int rowBlockOff = kRow * blocksPerRow;
+            float partial = 0.0f;
+            for (int j = localId; j < inputDim; j += localWorkGroupSize) {
+                int blockIdx = j / blockSize;
+                int withinBlock = j % blockSize;
+                int blockByteOff = (rowBlockOff + blockIdx) * Q8_0_BLOCK_BYTES;
+                HalfFloat sc = wk.getHalfFloat(blockByteOff);
+                byte q8 = wk.get(blockByteOff + 2 + withinBlock);
+                partial += ((float) q8 * sc.getFloat32()) * wrapXbBatch.get(inputOff + j);
+            }
+            localSum[localId] = partial;
+            context.localBarrier();
+            for (int s = localWorkGroupSize / 2; s > 0; s >>= 1) {
+                if (localId < s) localSum[localId] += localSum[localId + s];
+                context.localBarrier();
+            }
+            if (localId == 0) wrapKBatch.set(batchIdx * kvDim + kRow, localSum[0]);
+
+        } else {
+            int vRow = rowIdx - qDim - kvDim;
+            int blocksPerRow = (inputDim + blockSize - 1) / blockSize;
+            int rowBlockOff = vRow * blocksPerRow;
+            float partial = 0.0f;
+            for (int j = localId; j < inputDim; j += localWorkGroupSize) {
+                int blockIdx = j / blockSize;
+                int withinBlock = j % blockSize;
+                int blockByteOff = (rowBlockOff + blockIdx) * Q8_0_BLOCK_BYTES;
+                HalfFloat sc = wv.getHalfFloat(blockByteOff);
+                byte q8 = wv.get(blockByteOff + 2 + withinBlock);
+                partial += ((float) q8 * sc.getFloat32()) * wrapXbBatch.get(inputOff + j);
+            }
+            localSum[localId] = partial;
+            context.localBarrier();
+            for (int s = localWorkGroupSize / 2; s > 0; s >>= 1) {
+                if (localId < s) localSum[localId] += localSum[localId + s];
+                context.localBarrier();
+            }
+            if (localId == 0) wrapVBatch.set(batchIdx * kvDim + vRow, localSum[0]);
+        }
+    }
+
+    /**
+     * Batched fused Q/K RMSNorm for Qwen3 GQA.
+     *
+     * <p>Workgroup layout: B*(nHeads+nHeadKv) groups × nEmbdHead local threads.
+     * Groups [0, B*nHeads) normalize Q; groups [B*nHeads, B*(nHeads+nHeadKv)) normalize K.
+     * groupIdx = batchIdx*(nHeads+nHeadKv) + headSlot.</p>
+     *
+     * Worker: B*(nHeads+nHeadKv) workgroups × nEmbdHead threads.
+     */
+    public static void batchedFusedQKRmsNorm(
+            KernelContext context,
+            FloatArray wrapQBatch,
+            FloatArray wrapKBatch,
+            FloatArray qWeights,
+            FloatArray kWeights,
+            int nHeads,
+            int nHeadKv,
+            int nEmbdHead,
+            int qDim,
+            int kvDim,
+            float rmsNormEps) {
+
+        int groupId = context.globalIdx / nEmbdHead;
+        int localId = context.localIdx;
+        int localSize = context.localGroupSizeX;
+        int totalHeadsPerBatch = nHeads + nHeadKv;
+
+        int batchIdx = groupId / totalHeadsPerBatch;
+        int headSlot = groupId % totalHeadsPerBatch;
+
+        float[] localSum = context.allocateFloatLocalArray(nEmbdHead);
+
+        if (headSlot < nHeads) {
+            // Q head
+            int headOffset = batchIdx * qDim + headSlot * nEmbdHead;
+            float partialSum = 0.0f;
+            for (int i = localId; i < nEmbdHead; i += localSize) {
+                float val = wrapQBatch.get(headOffset + i);
+                partialSum += val * val;
+            }
+            localSum[localId] = partialSum;
+            context.localBarrier();
+            for (int stride = localSize / 2; stride > 0; stride >>= 1) {
+                if (localId < stride) localSum[localId] += localSum[localId + stride];
+                context.localBarrier();
+            }
+            float ss = localSum[0] / nEmbdHead + rmsNormEps;
+            ss = 1.0f / TornadoMath.sqrt(ss);
+            context.localBarrier();
+            for (int i = localId; i < nEmbdHead; i += localSize) {
+                wrapQBatch.set(headOffset + i, qWeights.get(i) * ss * wrapQBatch.get(headOffset + i));
+            }
+        } else {
+            // K head
+            int kHeadIdx = headSlot - nHeads;
+            int headOffset = batchIdx * kvDim + kHeadIdx * nEmbdHead;
+            float partialSum = 0.0f;
+            for (int i = localId; i < nEmbdHead; i += localSize) {
+                float val = wrapKBatch.get(headOffset + i);
+                partialSum += val * val;
+            }
+            localSum[localId] = partialSum;
+            context.localBarrier();
+            for (int stride = localSize / 2; stride > 0; stride >>= 1) {
+                if (localId < stride) localSum[localId] += localSum[localId + stride];
+                context.localBarrier();
+            }
+            float ss = localSum[0] / nEmbdHead + rmsNormEps;
+            ss = 1.0f / TornadoMath.sqrt(ss);
+            context.localBarrier();
+            for (int i = localId; i < nEmbdHead; i += localSize) {
+                wrapKBatch.set(headOffset + i, kWeights.get(i) * ss * wrapKBatch.get(headOffset + i));
+            }
+        }
+    }
+
+    /**
+     * Batched fused RoPE rotation + KV cache write for Qwen3.
+     *
+     * <p>Like {@code TransformerBatchPrefillKernels.batchedRopeWithKVCache} but uses
+     * Qwen3 RoPE theta (1 000 000) and a separate {@code qDim} for the Q stride.</p>
+     *
+     * <p>globalIdx = batchIdx*(qDim/2) + pairIdx.
+     * K rotation is applied only when pairIdx &lt; kvDim/2.</p>
+     *
+     * Worker: B*(qDim/2) global threads, localSize tuned like Llama RoPE.
+     */
+    public static void batchedRopeWithKVCacheQwen3(
+            KernelContext context,
+            IntArray batchStartPosHolder,
+            FloatArray wrapQBatch,
+            FloatArray wrapKBatch,
+            FloatArray wrapVBatch,
+            FloatArray wrapKeyCache,
+            FloatArray wrapValueCache,
+            int kvDim,
+            int nEmbdHead,
+            int layerIndex,
+            int contextLength,
+            int qDim) {
+
+        int globalIdx = context.globalIdx;
+        int halfQDim = qDim / 2;
+        int batchIdx = globalIdx / halfQDim;
+        int pairIdx = globalIdx % halfQDim;
+
+        int pos = batchStartPosHolder.get(0) + batchIdx;
+
+        // Qwen3 uses split-half RoPE: pair element ic with ic + nEmbdHead/2 within each head.
+        int halfEmbdHead = nEmbdHead / 2;
+        int ic      = pairIdx % halfEmbdHead;
+        int headIdx = pairIdx / halfEmbdHead;
+
+        float freq = 1.0f / TornadoMath.pow(1000000.0f, 2.0f * ic / (float) nEmbdHead);
+        float val  = pos * freq;
+        float fcr  = TornadoMath.cos(val);
+        float fci  = TornadoMath.sin(val);
+
+        // Rotate Q (split-half pairs within each head)
+        int qHeadBase = batchIdx * qDim + headIdx * nEmbdHead;
+        float v0q = wrapQBatch.get(qHeadBase + ic);
+        float v1q = wrapQBatch.get(qHeadBase + ic + halfEmbdHead);
+        wrapQBatch.set(qHeadBase + ic,              v0q * fcr - v1q * fci);
+        wrapQBatch.set(qHeadBase + ic + halfEmbdHead, v0q * fci + v1q * fcr);
+
+        // Rotate K and write K,V to cache (only for KV pairs)
+        if (pairIdx < kvDim / 2) {
+            int kHeadIdx  = pairIdx / halfEmbdHead;
+            int kHeadBase = batchIdx * kvDim + kHeadIdx * nEmbdHead;
+            float v0k = wrapKBatch.get(kHeadBase + ic);
+            float v1k = wrapKBatch.get(kHeadBase + ic + halfEmbdHead);
+            float rotK0 = v0k * fcr - v1k * fci;
+            float rotK1 = v0k * fci + v1k * fcr;
+            wrapKBatch.set(kHeadBase + ic,              rotK0);
+            wrapKBatch.set(kHeadBase + ic + halfEmbdHead, rotK1);
+
+            int cacheOff = layerIndex * contextLength * kvDim + pos * kvDim + kHeadIdx * nEmbdHead;
+            wrapKeyCache.set(cacheOff + ic,              rotK0);
+            wrapKeyCache.set(cacheOff + ic + halfEmbdHead, rotK1);
+            wrapValueCache.set(cacheOff + ic,              wrapVBatch.get(kHeadBase + ic));
+            wrapValueCache.set(cacheOff + ic + halfEmbdHead, wrapVBatch.get(kHeadBase + ic + halfEmbdHead));
+        }
+    }
 }
 // @formatter:on

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/Qwen3FP16FFNLayers.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/Qwen3FP16FFNLayers.java
@@ -24,7 +24,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3TornadoWeights, Qwen3Configuration> {
 
     // Typed reference to Qwen3-specific state
-    private final Qwen3State qwen3State;
+    protected final Qwen3State qwen3State;
     // Qwen3-specific GQA parameters
     private final int nHeadKv;
     private final int nEmbdHeadK;
@@ -192,7 +192,12 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
         var unifiedLayer = new TaskGraph(taskGraphName);
 
         // === Data Setup ===
-        unifiedLayer.consumeFromDevice(state.wrapX);
+        String wrapXSrc = predecessorGraphName(layerIndex);
+        if (wrapXSrc != null) {
+            unifiedLayer.consumeFromDevice(wrapXSrc, state.wrapX);
+        } else {
+            unifiedLayer.consumeFromDevice(state.wrapX);
+        }
         unifiedLayer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
                 // Attention weights
                 weights.rms_att_weightLayered[layerIndex].asFloatArray(),   // RMS norm weights
@@ -356,11 +361,26 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
                         config.hiddenDim(),      // input dim
                         config.dim(),            // output dim
                         LOCAL_WORK_GROUP_SIZE_ALLOC)
-                .persistOnDevice(qwen3State.wrapX);
+                .persistOnDevice(qwen3State.wrapX, qwen3State.wrapKeyCache, qwen3State.wrapValueCache);
 
         return unifiedLayer;
     }
     // @formatter:on
+
+    /**
+     * Returns the explicit predecessor graph name for consumeFromDevice.
+     *
+     * <p>The single-token plan receives {@code wrapX} (and relays all persisted buffers,
+     * including the KV cache) from a named predecessor graph: the activation graph for
+     * layer 0, the previous layer graph otherwise. The no-arg consume form looks up the
+     * <em>current</em> graph's name as the source key, which never matches in interpreter
+     * mode, so the persisted KV-cache buffer is not propagated and gets re-allocated every
+     * decode token — exhausting the device-memory pool (OOM) on long generations.
+     * Decode subclasses override this with their own predecessor names.</p>
+     */
+    protected String predecessorGraphName(int layerIndex) {
+        return (layerIndex == 0) ? "activationUpdate" : "layer_" + (layerIndex - 1);
+    }
 
     /**
      * Configure data transfers for first and subsequent layers
@@ -377,8 +397,12 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
                     qwen3State.wrapKeyCache, qwen3State.wrapValueCache,  //
                     qwen3State.wrapAtt, qwen3State.wrapHb );
         } else {
-            // Subsequent layers: Consume data from previous layer
-            unifiedLayer.consumeFromDevice(context, qwen3State.wrapXb, qwen3State.wrapXb2, //
+            // Subsequent layers: consume from the previous layer graph BY NAME.
+            // The no-arg consumeFromDevice form uses the current graph's own name as the
+            // source key, which never matches the predecessor in interpreter mode, so the
+            // persisted KV cache is not propagated and is re-allocated every token (OOM).
+            String pred = "layer_" + (layerIndex - 1);
+            unifiedLayer.consumeFromDevice(pred, context, qwen3State.wrapXb, qwen3State.wrapXb2, //
                     qwen3State.wrapQ, qwen3State.wrapK,  //
                     qwen3State.wrapV, qwen3State.wrapKeyCache, //
                     qwen3State.wrapValueCache, qwen3State.wrapAtt, //

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16FFNLayersDecode.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16FFNLayersDecode.java
@@ -1,0 +1,59 @@
+package org.beehive.gpullama3.tornadovm.layers.type.fp16.decode;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.Qwen3FP16FFNLayers;
+import org.beehive.gpullama3.tornadovm.scheduling.SchedulerType;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+
+/**
+ * Decode transformer-layer TaskGraphs for the unified batched prefill-decode plan (Qwen3 FP16).
+ *
+ * <p>Layer 0: KV cache is consumed from "decodeActivation" (already allocated by the batch
+ * prefill phase). Working buffers get FIRST_EXECUTION allocation. Layers 1+: all consumed
+ * objects use the explicit predecessor name to satisfy TornadoVM interpreter mode.</p>
+ *
+ * <p>Qwen3FP16FFNLayers does not use wrapXbFP16 in any task, so it is excluded.</p>
+ */
+public class Qwen3FP16FFNLayersDecode extends Qwen3FP16FFNLayers {
+
+    public Qwen3FP16FFNLayersDecode(String taskGraph, Qwen3State state,
+                                    Qwen3TornadoWeights weights, Qwen3Configuration config,
+                                    SchedulerType schedulerType) {
+        super(taskGraph, state, weights, config, schedulerType);
+    }
+
+    @Override
+    protected String predecessorGraphName(int layerIndex) {
+        return (layerIndex == 0) ? "decodeActivation" : "layer_" + (layerIndex - 1);
+    }
+
+    @Override
+    protected TaskGraph configureLayerDataTransfers(TaskGraph layer, int layerIndex) {
+        if (layerIndex == 0) {
+            layer.transferToDevice(DataTransferMode.EVERY_EXECUTION,
+                    qwen3State.positionHolder, qwen3State.temp, qwen3State.tempFFN);
+            layer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    context,
+                    qwen3State.wrapXb, qwen3State.wrapXb2,
+                    qwen3State.wrapQ, qwen3State.wrapK, qwen3State.wrapV,
+                    qwen3State.wrapAtt, qwen3State.wrapHb);
+            // KV cache already allocated by batch prefill; relay from decode activation graph.
+            layer.consumeFromDevice("decodeActivation",
+                    qwen3State.wrapKeyCache, qwen3State.wrapValueCache);
+        } else {
+            String pred = "layer_" + (layerIndex - 1);
+            layer.consumeFromDevice(pred,
+                    context,
+                    qwen3State.wrapXb, qwen3State.wrapXb2,
+                    qwen3State.wrapQ, qwen3State.wrapK, qwen3State.wrapV,
+                    qwen3State.wrapKeyCache, qwen3State.wrapValueCache,
+                    qwen3State.wrapAtt, qwen3State.wrapHb,
+                    qwen3State.positionHolder,
+                    qwen3State.temp, qwen3State.tempFFN);
+        }
+        return layer;
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16FFNLayersPrefillDecode.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16FFNLayersPrefillDecode.java
@@ -1,0 +1,48 @@
+package org.beehive.gpullama3.tornadovm.layers.type.fp16.decode;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.Qwen3FP16FFNLayers;
+import org.beehive.gpullama3.tornadovm.scheduling.SchedulerType;
+import uk.ac.manchester.tornado.api.TaskGraph;
+
+/**
+ * Decode transformer-layer TaskGraphs for the single-token prefill/decode plan (Qwen3 FP16).
+ *
+ * <p>Layer 0 delegates to the base-class {@link Qwen3FP16FFNLayers#configureLayerDataTransfers}
+ * which allocates wrapKeyCache/wrapValueCache with FIRST_EXECUTION. Layers 1+ consume all
+ * live buffers from the explicit predecessor graph to satisfy TornadoVM interpreter mode.</p>
+ *
+ * <p>Note: Qwen3FP16FFNLayers does not use wrapXbFP16 in any kernel task, so it is
+ * intentionally excluded from the consume list.</p>
+ */
+public class Qwen3FP16FFNLayersPrefillDecode extends Qwen3FP16FFNLayers {
+
+    public Qwen3FP16FFNLayersPrefillDecode(String taskGraph, Qwen3State state,
+                                           Qwen3TornadoWeights weights, Qwen3Configuration config,
+                                           SchedulerType schedulerType) {
+        super(taskGraph, state, weights, config, schedulerType);
+    }
+
+    @Override
+    protected String predecessorGraphName(int layerIndex) {
+        return (layerIndex == 0) ? "decodeActivation" : "layer_" + (layerIndex - 1);
+    }
+
+    @Override
+    protected TaskGraph configureLayerDataTransfers(TaskGraph layer, int layerIndex) {
+        if (layerIndex == 0) {
+            return super.configureLayerDataTransfers(layer, 0);
+        }
+        String pred = "layer_" + (layerIndex - 1);
+        layer.consumeFromDevice(pred,
+                context,
+                qwen3State.wrapXb, qwen3State.wrapXb2,
+                qwen3State.wrapQ, qwen3State.wrapK, qwen3State.wrapV,
+                qwen3State.wrapKeyCache, qwen3State.wrapValueCache,
+                qwen3State.wrapAtt, qwen3State.wrapHb,
+                qwen3State.positionHolder);
+        return layer;
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/prefill/Qwen3FP16LayersBatchPrefill.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/prefill/Qwen3FP16LayersBatchPrefill.java
@@ -1,0 +1,253 @@
+package org.beehive.gpullama3.tornadovm.layers.type.fp16.prefill;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.kernels.Qwen3Kernels;
+import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
+import org.beehive.gpullama3.tornadovm.scheduling.WorkerGridFactory;
+import org.beehive.gpullama3.tornadovm.layers.BatchPrefillTransformerLayerTaskGraphs;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Batched-prefill transformer-layer TaskGraphs for the Qwen3 FP16 unified batched prefill-decode plan.
+ *
+ * <p>Mirrors {@link LlamaFP16LayersBatchPrefill} but adapts to Qwen3's GQA layout and
+ * Qwen3-specific kernels (fused Q/K RMSNorm, RoPE theta = 1 000 000). Avoids any calls to
+ * {@code Qwen3Configuration.headSize()}, {@code kvDim()}, or {@code kvMul()} which throw.</p>
+ */
+public class Qwen3FP16LayersBatchPrefill implements BatchPrefillTransformerLayerTaskGraphs {
+
+    static final int LOCAL_WORK_GROUP_SIZE = 32;
+
+    private final Qwen3State state;
+    private final Qwen3TornadoWeights weights;
+    private final Qwen3Configuration config;
+    private final KernelContext context = new KernelContext();
+    private final int batchSize;
+    private final int nHeadKv;
+    private final int nEmbdHeadK;
+    private final int nEmbdHeadV;
+    private final int nEmbdHead;
+    private final int qDim;
+    private final int kvDim;
+    private final int gqa;
+    private final List<ImmutableTaskGraph> layerITGs;
+    private String lastLayerTaskGraphID;
+
+    public Qwen3FP16LayersBatchPrefill(Qwen3State state, Qwen3TornadoWeights weights,
+                                       Qwen3Configuration config, int batchSize) {
+        this.state = state;
+        this.weights = weights;
+        this.config = config;
+        this.batchSize = batchSize;
+        this.nHeadKv = config.numberOfKeyValueHeads();
+        this.nEmbdHeadK = config.numberOfHeadsKey();
+        this.nEmbdHeadV = config.numberOfHeadsValue();
+        this.nEmbdHead = nEmbdHeadV;
+        this.qDim = nEmbdHeadK * config.numberOfHeads();
+        this.kvDim = nEmbdHeadV * nHeadKv;
+        this.gqa = config.numberOfHeads() / nHeadKv;
+        this.layerITGs = IntStream.range(0, config.numberOfLayers())
+                .mapToObj(this::createBatchPrefillLayerTaskGraph)
+                .map(TaskGraph::snapshot)
+                .toList();
+    }
+
+    // @formatter:off
+    private TaskGraph createBatchPrefillLayerTaskGraph(int layerIndex) {
+        String graphName = "batchPrefillLayer_" + layerIndex;
+        if (layerIndex == config.numberOfLayers() - 1) lastLayerTaskGraphID = graphName;
+
+        TaskGraph layer = new TaskGraph(graphName);
+        int dim    = config.dim();
+        int hidDim = config.hiddenDim();
+
+        // ── Data Transfers ─────────────────────────────────────────────────────
+        if (layerIndex == 0) {
+            layer.transferToDevice(DataTransferMode.EVERY_EXECUTION, state.batchStartPosHolder);
+            layer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    context,
+                    state.attnScaleBatch, state.ffnScaleBatch,
+                    state.wrapXbFP16Batch,
+                    state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                    state.wrapXbBatch,
+                    state.wrapHbBatch,
+                    state.wrapKeyCache, state.wrapValueCache);
+            layer.consumeFromDevice("prefillActivation", state.wrapXBatch);
+        } else {
+            String pred = "batchPrefillLayer_" + (layerIndex - 1);
+            layer.consumeFromDevice(pred,
+                    context,
+                    state.wrapXBatch,
+                    state.wrapXbFP16Batch,
+                    state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                    state.wrapXbBatch,
+                    state.wrapHbBatch,
+                    state.wrapKeyCache, state.wrapValueCache,
+                    state.batchStartPosHolder,
+                    state.attnScaleBatch, state.ffnScaleBatch);
+        }
+
+        // Per-layer weights: upload once
+        layer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                weights.wqLayered[layerIndex].asHalfFloatArray(),
+                weights.wkLayered[layerIndex].asHalfFloatArray(),
+                weights.wvLayered[layerIndex].asHalfFloatArray(),
+                weights.woLayered[layerIndex].asHalfFloatArray(),
+                weights.rms_att_QNormLayered[layerIndex].asFloatArray(),
+                weights.rms_att_KNormLayered[layerIndex].asFloatArray(),
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                weights.w1Layered[layerIndex].asHalfFloatArray(),
+                weights.w2Layered[layerIndex].asHalfFloatArray(),
+                weights.w3Layered[layerIndex].asHalfFloatArray());
+
+        // ── Attention Block ────────────────────────────────────────────────────
+        layer.task("batch_attn_rms",
+                TransformerBatchPrefillKernels::batchedRmsReduce,
+                context, state.wrapXBatch, state.attnScaleBatch,
+                dim, config.rmsNormEps());
+
+        layer.task("batch_attn_rms_apply",
+                TransformerBatchPrefillKernels::batchedRmsApplyFP16,
+                context, state.wrapXbFP16Batch, state.wrapXBatch,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                state.attnScaleBatch, dim);
+
+        layer.task("batch_qkv",
+                Qwen3Kernels::batchedFusedQKVMatmulFP16,
+                context,
+                state.wrapXbFP16Batch,
+                state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                weights.wqLayered[layerIndex].asHalfFloatArray(),
+                weights.wkLayered[layerIndex].asHalfFloatArray(),
+                weights.wvLayered[layerIndex].asHalfFloatArray(),
+                dim, qDim, kvDim, LOCAL_WORK_GROUP_SIZE);
+
+        layer.task("batch_qk_rmsnorm",
+                Qwen3Kernels::batchedFusedQKRmsNorm,
+                context,
+                state.wrapQBatch, state.wrapKBatch,
+                weights.rms_att_QNormLayered[layerIndex].asFloatArray(),
+                weights.rms_att_KNormLayered[layerIndex].asFloatArray(),
+                config.numberOfHeads(), nHeadKv, nEmbdHead,
+                qDim, kvDim, config.rmsNormEps());
+
+        layer.task("batch_rope_kv",
+                Qwen3Kernels::batchedRopeWithKVCacheQwen3,
+                context, state.batchStartPosHolder,
+                state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                state.wrapKeyCache, state.wrapValueCache,
+                kvDim, nEmbdHead, layerIndex, config.contextLength(), qDim);
+
+        // Reuses batchedFlashAttention: passes qDim as the 'dim' stride parameter.
+        // Valid because qDim == dim for all standard Qwen3 models (nEmbdHeadK = dim/nHeads).
+        layer.task("batch_attention",
+                TransformerBatchPrefillKernels::batchedFlashAttention,
+                context, state.batchStartPosHolder,
+                state.wrapQBatch, state.wrapKeyCache, state.wrapValueCache,
+                state.wrapXbBatch,
+                config.numberOfHeads(), nEmbdHead,
+                kvDim, gqa, layerIndex, config.contextLength(), qDim);
+
+        // Output projection: n=qDim (input), d=dim (output)
+        layer.task("batch_attn_out",
+                TransformerBatchPrefillKernels::batchedMatVecWithResidual,
+                context, state.wrapXbBatch, state.wrapXBatch,
+                weights.woLayered[layerIndex].asHalfFloatArray(),
+                qDim, dim, LOCAL_WORK_GROUP_SIZE);
+
+        // ── FFN Block ──────────────────────────────────────────────────────────
+        layer.task("batch_ffn_rms",
+                TransformerBatchPrefillKernels::batchedFFNRmsReduce,
+                context, state.wrapXBatch, state.ffnScaleBatch,
+                dim, config.rmsNormEps());
+
+        layer.task("batch_ffn_gate_up",
+                TransformerBatchPrefillKernels::batchedFusedRmsNormFFNGateUp,
+                context, state.wrapXBatch, state.wrapHbBatch,
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                state.ffnScaleBatch,
+                weights.w1Layered[layerIndex].asHalfFloatArray(),
+                weights.w3Layered[layerIndex].asHalfFloatArray(),
+                dim, hidDim, LOCAL_WORK_GROUP_SIZE);
+
+        layer.task("batch_ffn_down",
+                TransformerBatchPrefillKernels::batchedMatVecWithResidual,
+                context, state.wrapHbBatch, state.wrapXBatch,
+                weights.w2Layered[layerIndex].asHalfFloatArray(),
+                hidDim, dim, LOCAL_WORK_GROUP_SIZE);
+
+        layer.persistOnDevice(state.wrapXBatch, state.wrapKeyCache, state.wrapValueCache);
+
+        return layer;
+    }
+    // @formatter:on
+
+    public void updateGridScheduler(GridScheduler scheduler) {
+        int dim    = config.dim();
+        int hidDim = config.hiddenDim();
+
+        WorkerGrid rmsWorker        = WorkerGridFactory.genericWorker(batchSize, 1);
+        WorkerGrid rmsApplyWorker   = WorkerGridFactory.genericWorker(batchSize * dim, 256);
+
+        int qkvRows = qDim + 2 * kvDim;
+        WorkerGrid qkvWorker = WorkerGridFactory.genericWorker(
+                batchSize * qkvRows * LOCAL_WORK_GROUP_SIZE, LOCAL_WORK_GROUP_SIZE);
+
+        WorkerGrid qkRmsNormWorker = WorkerGridFactory.genericWorker(
+                batchSize * (config.numberOfHeads() + nHeadKv) * nEmbdHead, nEmbdHead);
+
+        int ropeGlobal = batchSize * (qDim / 2);
+        int ropeLocal  = Math.min(512, ropeGlobal);
+        while (ropeLocal > 1 && ropeGlobal % ropeLocal != 0) ropeLocal--;
+        WorkerGrid ropeWorker = WorkerGridFactory.genericWorker(ropeGlobal, ropeLocal);
+
+        int optLocal = findOptimalLocalSize(nEmbdHead);
+        WorkerGrid attnWorker = WorkerGridFactory.genericWorker(
+                batchSize * config.numberOfHeads() * optLocal, optLocal);
+
+        // Wo: B*dim output rows (n=qDim, d=dim)
+        WorkerGrid matVecDimWorker = WorkerGridFactory.genericWorker(
+                batchSize * dim * LOCAL_WORK_GROUP_SIZE, LOCAL_WORK_GROUP_SIZE);
+        WorkerGrid matVecHidWorker = WorkerGridFactory.genericWorker(
+                batchSize * hidDim * LOCAL_WORK_GROUP_SIZE, LOCAL_WORK_GROUP_SIZE);
+
+        for (int i = 0; i < config.numberOfLayers(); i++) {
+            String p = "batchPrefillLayer_" + i + ".";
+            scheduler.addWorkerGrid(p + "batch_attn_rms",       rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_attn_rms_apply", rmsApplyWorker);
+            scheduler.addWorkerGrid(p + "batch_qkv",            qkvWorker);
+            scheduler.addWorkerGrid(p + "batch_qk_rmsnorm",     qkRmsNormWorker);
+            scheduler.addWorkerGrid(p + "batch_rope_kv",        ropeWorker);
+            scheduler.addWorkerGrid(p + "batch_attention",      attnWorker);
+            scheduler.addWorkerGrid(p + "batch_attn_out",       matVecDimWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_rms",        rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_gate_up",    matVecHidWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_down",       matVecDimWorker);
+        }
+    }
+
+    private static int findOptimalLocalSize(int size) {
+        int optimal = Math.min(size, 64);
+        if (size % optimal != 0) {
+            for (int s = 64; s >= 1; s--) {
+                if (size % s == 0) { optimal = s; break; }
+            }
+        }
+        return optimal;
+    }
+
+    public List<ImmutableTaskGraph> getLayerImmutableTaskGraphs() { return layerITGs; }
+    public String getLastLayerTaskGraphID()                        { return lastLayerTaskGraphID; }
+    public KernelContext getContext()                               { return context; }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/Qwen3Q8_0FFNLayers.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/Qwen3Q8_0FFNLayers.java
@@ -28,7 +28,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 public class Qwen3Q8_0FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3TornadoWeights, Qwen3Configuration> {
 
     // Typed reference to Qwen3-specific state
-    private final Qwen3State qwen3State;
+    protected final Qwen3State qwen3State;
 
     // Qwen3-specific GQA parameters
     private final int nHeadKv;
@@ -110,7 +110,12 @@ public class Qwen3Q8_0FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
         var unifiedLayer = new TaskGraph(taskGraphName);
 
         // === Data Setup ===
-        unifiedLayer.consumeFromDevice(qwen3State.wrapX);
+        String wrapXSrc = predecessorGraphName(layerIndex);
+        if (wrapXSrc != null) {
+            unifiedLayer.consumeFromDevice(wrapXSrc, qwen3State.wrapX);
+        } else {
+            unifiedLayer.consumeFromDevice(qwen3State.wrapX);
+        }
         unifiedLayer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
                 // Attention weights
                 weights.rms_att_weightLayered[layerIndex].asFloatArray(),   // RMS norm weights
@@ -275,11 +280,24 @@ public class Qwen3Q8_0FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
                         config.dim(),           // output dim
                         LOCAL_WORK_GROUP_SIZE_ALLOC);
 
-        unifiedLayer.persistOnDevice(state.wrapX);
+        unifiedLayer.persistOnDevice(state.wrapX, state.wrapKeyCache, state.wrapValueCache);
 
         return unifiedLayer;
     }
     // @formatter:on
+
+    /**
+     * Returns the explicit predecessor graph name for consumeFromDevice.
+     *
+     * <p>The single-token plan relays all persisted buffers (including the KV cache) from a
+     * named predecessor graph: the activation graph for layer 0, the previous layer graph
+     * otherwise. The no-arg consume form does not propagate the persisted KV cache in
+     * interpreter mode, so it is re-allocated every decode token and exhausts the device
+     * memory pool (OOM) on long generations. Decode subclasses override this.</p>
+     */
+    protected String predecessorGraphName(int layerIndex) {
+        return (layerIndex == 0) ? "activationUpdate" : "layer_" + (layerIndex - 1);
+    }
 
     /**
      * Configure data transfers for first and subsequent layers
@@ -304,8 +322,12 @@ public class Qwen3Q8_0FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
                                                                             qwen3State.wrapAtt,
                                                                             qwen3State.wrapHb);
         } else {
-            // Subsequent layers: Consume data from previous layer
-            unifiedLayer.consumeFromDevice(context,
+            // Subsequent layers: consume from the previous layer graph BY NAME. The no-arg
+            // consume form does not propagate the persisted KV cache in interpreter mode, so
+            // it would be re-allocated every decode token and exhaust the memory pool (OOM).
+            String pred = "layer_" + (layerIndex - 1);
+            unifiedLayer.consumeFromDevice(pred,
+                                           context,
                                            qwen3State.wrapXb,
                                            qwen3State.wrapXb2,
                                            qwen3State.wrapQ,
@@ -317,8 +339,7 @@ public class Qwen3Q8_0FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
                                            qwen3State.wrapHb,
                                            qwen3State.positionHolder);
 
-            Qwen3State qwen3State = (Qwen3State) state;
-            unifiedLayer.consumeFromDevice(qwen3State.tempQcur, qwen3State.tempKcur); //
+            unifiedLayer.consumeFromDevice(pred, qwen3State.tempQcur, qwen3State.tempKcur); //
         }
         return unifiedLayer;
     }

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/decode/Qwen3Q8_0FFNLayersDecode.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/decode/Qwen3Q8_0FFNLayersDecode.java
@@ -1,0 +1,59 @@
+package org.beehive.gpullama3.tornadovm.layers.type.q8_0.decode;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.layers.type.q8_0.Qwen3Q8_0FFNLayers;
+import org.beehive.gpullama3.tornadovm.scheduling.SchedulerType;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+
+/**
+ * Decode transformer-layer TaskGraphs for the unified batched prefill-decode plan (Qwen3 Q8_0).
+ *
+ * <p>Layer 0: KV cache consumed from "decodeActivation" (already allocated by batch prefill).
+ * Layers 1+: all consumed objects use explicit predecessor name for interpreter mode.</p>
+ */
+public class Qwen3Q8_0FFNLayersDecode extends Qwen3Q8_0FFNLayers {
+
+    public Qwen3Q8_0FFNLayersDecode(String taskGraph, Qwen3State state,
+                                    Qwen3TornadoWeights weights, Qwen3Configuration config,
+                                    SchedulerType schedulerType) {
+        super(taskGraph, state, weights, config, schedulerType);
+    }
+
+    @Override
+    protected String predecessorGraphName(int layerIndex) {
+        return (layerIndex == 0) ? "decodeActivation" : "layer_" + (layerIndex - 1);
+    }
+
+    @Override
+    protected TaskGraph configureLayerDataTransfers(TaskGraph layer, int layerIndex) {
+        if (layerIndex == 0) {
+            layer.transferToDevice(DataTransferMode.EVERY_EXECUTION,
+                    qwen3State.positionHolder, qwen3State.temp, qwen3State.tempFFN);
+            layer.transferToDevice(DataTransferMode.EVERY_EXECUTION,
+                    qwen3State.tempQcur, qwen3State.tempKcur);
+            layer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    context,
+                    qwen3State.wrapXb, qwen3State.wrapXb2,
+                    qwen3State.wrapQ, qwen3State.wrapK, qwen3State.wrapV,
+                    qwen3State.wrapAtt, qwen3State.wrapHb);
+            // KV cache already allocated by batch prefill; relay from decode activation graph.
+            layer.consumeFromDevice("decodeActivation",
+                    qwen3State.wrapKeyCache, qwen3State.wrapValueCache);
+        } else {
+            String pred = "layer_" + (layerIndex - 1);
+            layer.consumeFromDevice(pred,
+                    context,
+                    qwen3State.wrapXb, qwen3State.wrapXb2,
+                    qwen3State.wrapQ, qwen3State.wrapK, qwen3State.wrapV,
+                    qwen3State.wrapKeyCache, qwen3State.wrapValueCache,
+                    qwen3State.wrapAtt, qwen3State.wrapHb,
+                    qwen3State.positionHolder,
+                    qwen3State.temp, qwen3State.tempFFN);
+            layer.consumeFromDevice(qwen3State.tempQcur, qwen3State.tempKcur);
+        }
+        return layer;
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/decode/Qwen3Q8_0FFNLayersPrefillDecode.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/decode/Qwen3Q8_0FFNLayersPrefillDecode.java
@@ -1,0 +1,45 @@
+package org.beehive.gpullama3.tornadovm.layers.type.q8_0.decode;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.layers.type.q8_0.Qwen3Q8_0FFNLayers;
+import org.beehive.gpullama3.tornadovm.scheduling.SchedulerType;
+import uk.ac.manchester.tornado.api.TaskGraph;
+
+/**
+ * Decode transformer-layer TaskGraphs for the single-token prefill/decode plan (Qwen3 Q8_0).
+ *
+ * <p>Layer 0 delegates to the base-class which allocates wrapKeyCache/wrapValueCache with
+ * FIRST_EXECUTION. Layers 1+ consume all live buffers from the explicit predecessor graph.</p>
+ */
+public class Qwen3Q8_0FFNLayersPrefillDecode extends Qwen3Q8_0FFNLayers {
+
+    public Qwen3Q8_0FFNLayersPrefillDecode(String taskGraph, Qwen3State state,
+                                           Qwen3TornadoWeights weights, Qwen3Configuration config,
+                                           SchedulerType schedulerType) {
+        super(taskGraph, state, weights, config, schedulerType);
+    }
+
+    @Override
+    protected String predecessorGraphName(int layerIndex) {
+        return (layerIndex == 0) ? "decodeActivation" : "layer_" + (layerIndex - 1);
+    }
+
+    @Override
+    protected TaskGraph configureLayerDataTransfers(TaskGraph layer, int layerIndex) {
+        if (layerIndex == 0) {
+            return super.configureLayerDataTransfers(layer, 0);
+        }
+        String pred = "layer_" + (layerIndex - 1);
+        layer.consumeFromDevice(pred,
+                context,
+                qwen3State.wrapXb, qwen3State.wrapXb2,
+                qwen3State.wrapQ, qwen3State.wrapK, qwen3State.wrapV,
+                qwen3State.wrapKeyCache, qwen3State.wrapValueCache,
+                qwen3State.wrapAtt, qwen3State.wrapHb,
+                qwen3State.positionHolder);
+        layer.consumeFromDevice(qwen3State.tempQcur, qwen3State.tempKcur);
+        return layer;
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/prefill/Qwen3Q8_0LayersBatchPrefill.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/q8_0/prefill/Qwen3Q8_0LayersBatchPrefill.java
@@ -1,0 +1,250 @@
+package org.beehive.gpullama3.tornadovm.layers.type.q8_0.prefill;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.kernels.Qwen3Kernels;
+import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
+import org.beehive.gpullama3.tornadovm.scheduling.WorkerGridFactory;
+import org.beehive.gpullama3.tornadovm.layers.BatchPrefillTransformerLayerTaskGraphs;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Batched-prefill transformer-layer TaskGraphs for the Qwen3 Q8_0 unified batched prefill-decode plan.
+ *
+ * <p>Q8_0 path: wrapXbBatch (FP32) holds normalized activations; wrapXbFP16Batch is not used.
+ * Mirrors {@link Qwen3FP16LayersBatchPrefill} but uses Q8_0 weights (ByteArray) and FP32
+ * attention normalization path.</p>
+ */
+public class Qwen3Q8_0LayersBatchPrefill implements BatchPrefillTransformerLayerTaskGraphs {
+
+    static final int LOCAL_WORK_GROUP_SIZE = 32;
+
+    private final Qwen3State state;
+    private final Qwen3TornadoWeights weights;
+    private final Qwen3Configuration config;
+    private final KernelContext context = new KernelContext();
+    private final int batchSize;
+    private final int nHeadKv;
+    private final int nEmbdHeadK;
+    private final int nEmbdHeadV;
+    private final int nEmbdHead;
+    private final int qDim;
+    private final int kvDim;
+    private final int gqa;
+    private final List<ImmutableTaskGraph> layerITGs;
+    private String lastLayerTaskGraphID;
+
+    public Qwen3Q8_0LayersBatchPrefill(Qwen3State state, Qwen3TornadoWeights weights,
+                                       Qwen3Configuration config, int batchSize) {
+        this.state = state;
+        this.weights = weights;
+        this.config = config;
+        this.batchSize = batchSize;
+        this.nHeadKv = config.numberOfKeyValueHeads();
+        this.nEmbdHeadK = config.numberOfHeadsKey();
+        this.nEmbdHeadV = config.numberOfHeadsValue();
+        this.nEmbdHead = nEmbdHeadV;
+        this.qDim = nEmbdHeadK * config.numberOfHeads();
+        this.kvDim = nEmbdHeadV * nHeadKv;
+        this.gqa = config.numberOfHeads() / nHeadKv;
+        this.layerITGs = IntStream.range(0, config.numberOfLayers())
+                .mapToObj(this::createBatchPrefillLayerTaskGraph)
+                .map(TaskGraph::snapshot)
+                .toList();
+    }
+
+    // @formatter:off
+    private TaskGraph createBatchPrefillLayerTaskGraph(int layerIndex) {
+        String graphName = "batchPrefillLayer_" + layerIndex;
+        if (layerIndex == config.numberOfLayers() - 1) lastLayerTaskGraphID = graphName;
+
+        TaskGraph layer = new TaskGraph(graphName);
+        int dim    = config.dim();
+        int hidDim = config.hiddenDim();
+
+        // ── Data Transfers ─────────────────────────────────────────────────────
+        if (layerIndex == 0) {
+            layer.transferToDevice(DataTransferMode.EVERY_EXECUTION, state.batchStartPosHolder);
+            layer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    context,
+                    state.attnScaleBatch, state.ffnScaleBatch,
+                    state.wrapXbBatch,
+                    state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                    state.wrapHbBatch,
+                    state.wrapKeyCache, state.wrapValueCache);
+            layer.consumeFromDevice("prefillActivation", state.wrapXBatch);
+        } else {
+            String pred = "batchPrefillLayer_" + (layerIndex - 1);
+            layer.consumeFromDevice(pred,
+                    context,
+                    state.wrapXBatch,
+                    state.wrapXbBatch,
+                    state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                    state.wrapHbBatch,
+                    state.wrapKeyCache, state.wrapValueCache,
+                    state.batchStartPosHolder,
+                    state.attnScaleBatch, state.ffnScaleBatch);
+        }
+
+        // Per-layer weights (Q8_0 format)
+        layer.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                weights.wqLayered[layerIndex].asByteArray(),
+                weights.wkLayered[layerIndex].asByteArray(),
+                weights.wvLayered[layerIndex].asByteArray(),
+                weights.woLayered[layerIndex].asByteArray(),
+                weights.rms_att_QNormLayered[layerIndex].asFloatArray(),
+                weights.rms_att_KNormLayered[layerIndex].asFloatArray(),
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                weights.w1Layered[layerIndex].asByteArray(),
+                weights.w2Layered[layerIndex].asByteArray(),
+                weights.w3Layered[layerIndex].asByteArray());
+
+        // ── Attention Block ────────────────────────────────────────────────────
+        layer.task("batch_attn_rms",
+                TransformerBatchPrefillKernels::batchedRmsReduce,
+                context, state.wrapXBatch, state.attnScaleBatch,
+                dim, config.rmsNormEps());
+
+        // FP32 normalize into wrapXbBatch (Q8_0 path: no FP16 quantize step)
+        layer.task("batch_attn_rms_apply",
+                TransformerBatchPrefillKernels::batchedRmsApplyFP32,
+                context, state.wrapXbBatch, state.wrapXBatch,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                state.attnScaleBatch, dim);
+
+        layer.task("batch_qkv",
+                Qwen3Kernels::batchedFusedQKVMatmulQ8_0,
+                context,
+                state.wrapXbBatch,
+                state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                weights.wqLayered[layerIndex].asByteArray(),
+                weights.wkLayered[layerIndex].asByteArray(),
+                weights.wvLayered[layerIndex].asByteArray(),
+                dim, qDim, kvDim, LOCAL_WORK_GROUP_SIZE);
+
+        layer.task("batch_qk_rmsnorm",
+                Qwen3Kernels::batchedFusedQKRmsNorm,
+                context,
+                state.wrapQBatch, state.wrapKBatch,
+                weights.rms_att_QNormLayered[layerIndex].asFloatArray(),
+                weights.rms_att_KNormLayered[layerIndex].asFloatArray(),
+                config.numberOfHeads(), nHeadKv, nEmbdHead,
+                qDim, kvDim, config.rmsNormEps());
+
+        layer.task("batch_rope_kv",
+                Qwen3Kernels::batchedRopeWithKVCacheQwen3,
+                context, state.batchStartPosHolder,
+                state.wrapQBatch, state.wrapKBatch, state.wrapVBatch,
+                state.wrapKeyCache, state.wrapValueCache,
+                kvDim, nEmbdHead, layerIndex, config.contextLength(), qDim);
+
+        // Reuses batchedFlashAttention; passes qDim as the 'dim' stride (valid: qDim==dim typically).
+        layer.task("batch_attention",
+                TransformerBatchPrefillKernels::batchedFlashAttention,
+                context, state.batchStartPosHolder,
+                state.wrapQBatch, state.wrapKeyCache, state.wrapValueCache,
+                state.wrapXbBatch,
+                config.numberOfHeads(), nEmbdHead,
+                kvDim, gqa, layerIndex, config.contextLength(), qDim);
+
+        // Output projection (Q8_0): n=qDim, d=dim
+        layer.task("batch_attn_out",
+                TransformerBatchPrefillKernels::batchedMatVecWithResidualQ8,
+                context, state.wrapXbBatch, state.wrapXBatch,
+                weights.woLayered[layerIndex].asByteArray(),
+                qDim, dim, LOCAL_WORK_GROUP_SIZE);
+
+        // ── FFN Block ──────────────────────────────────────────────────────────
+        layer.task("batch_ffn_rms",
+                TransformerBatchPrefillKernels::batchedFFNRmsReduce,
+                context, state.wrapXBatch, state.ffnScaleBatch,
+                dim, config.rmsNormEps());
+
+        layer.task("batch_ffn_gate_up",
+                TransformerBatchPrefillKernels::batchedFusedRmsNormFFNGateUpQ8,
+                context, state.wrapXBatch, state.wrapHbBatch,
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                state.ffnScaleBatch,
+                weights.w1Layered[layerIndex].asByteArray(),
+                weights.w3Layered[layerIndex].asByteArray(),
+                dim, hidDim, LOCAL_WORK_GROUP_SIZE);
+
+        layer.task("batch_ffn_down",
+                TransformerBatchPrefillKernels::batchedMatVecWithResidualQ8,
+                context, state.wrapHbBatch, state.wrapXBatch,
+                weights.w2Layered[layerIndex].asByteArray(),
+                hidDim, dim, LOCAL_WORK_GROUP_SIZE);
+
+        layer.persistOnDevice(state.wrapXBatch, state.wrapKeyCache, state.wrapValueCache);
+
+        return layer;
+    }
+    // @formatter:on
+
+    public void updateGridScheduler(GridScheduler scheduler) {
+        int dim    = config.dim();
+        int hidDim = config.hiddenDim();
+
+        WorkerGrid rmsWorker        = WorkerGridFactory.genericWorker(batchSize, 1);
+        WorkerGrid rmsApplyWorker   = WorkerGridFactory.genericWorker(batchSize * dim, 256);
+
+        int qkvRows = qDim + 2 * kvDim;
+        WorkerGrid qkvWorker = WorkerGridFactory.genericWorker(
+                batchSize * qkvRows * LOCAL_WORK_GROUP_SIZE, LOCAL_WORK_GROUP_SIZE);
+
+        WorkerGrid qkRmsNormWorker = WorkerGridFactory.genericWorker(
+                batchSize * (config.numberOfHeads() + nHeadKv) * nEmbdHead, nEmbdHead);
+
+        int ropeGlobal = batchSize * (qDim / 2);
+        int ropeLocal  = Math.min(512, ropeGlobal);
+        while (ropeLocal > 1 && ropeGlobal % ropeLocal != 0) ropeLocal--;
+        WorkerGrid ropeWorker = WorkerGridFactory.genericWorker(ropeGlobal, ropeLocal);
+
+        int optLocal = findOptimalLocalSize(nEmbdHead);
+        WorkerGrid attnWorker = WorkerGridFactory.genericWorker(
+                batchSize * config.numberOfHeads() * optLocal, optLocal);
+
+        WorkerGrid matVecDimWorker = WorkerGridFactory.genericWorker(
+                batchSize * dim * LOCAL_WORK_GROUP_SIZE, LOCAL_WORK_GROUP_SIZE);
+        WorkerGrid matVecHidWorker = WorkerGridFactory.genericWorker(
+                batchSize * hidDim * LOCAL_WORK_GROUP_SIZE, LOCAL_WORK_GROUP_SIZE);
+
+        for (int i = 0; i < config.numberOfLayers(); i++) {
+            String p = "batchPrefillLayer_" + i + ".";
+            scheduler.addWorkerGrid(p + "batch_attn_rms",       rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_attn_rms_apply", rmsApplyWorker);
+            scheduler.addWorkerGrid(p + "batch_qkv",            qkvWorker);
+            scheduler.addWorkerGrid(p + "batch_qk_rmsnorm",     qkRmsNormWorker);
+            scheduler.addWorkerGrid(p + "batch_rope_kv",        ropeWorker);
+            scheduler.addWorkerGrid(p + "batch_attention",      attnWorker);
+            scheduler.addWorkerGrid(p + "batch_attn_out",       matVecDimWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_rms",        rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_gate_up",    matVecHidWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_down",       matVecDimWorker);
+        }
+    }
+
+    private static int findOptimalLocalSize(int size) {
+        int optimal = Math.min(size, 64);
+        if (size % optimal != 0) {
+            for (int s = 64; s >= 1; s--) {
+                if (size % s == 0) { optimal = s; break; }
+            }
+        }
+        return optimal;
+    }
+
+    public List<ImmutableTaskGraph> getLayerImmutableTaskGraphs() { return layerITGs; }
+    public String getLastLayerTaskGraphID()                        { return lastLayerTaskGraphID; }
+    public KernelContext getContext()                               { return context; }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/plan/ForwardPlanFactory.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/plan/ForwardPlanFactory.java
@@ -176,15 +176,21 @@ public class ForwardPlanFactory {
     }
 
     private static ForwardPlan createQwen3FP16Plan(ExecutionMode mode, Qwen3State state, Model model) {
-        if (mode != ExecutionMode.STANDARD)
-            throw new UnsupportedOperationException(mode + " not yet supported for QWEN_3 + F16");
-        return new SingleTokenForwardPlan(model, new Qwen3FP16PlanComponents(state, model));
+        BatchPrefillDecodeForwardPlanComponents components = new Qwen3FP16PlanComponents(state, model);
+        return switch (mode) {
+            case STANDARD             -> new SingleTokenForwardPlan(model, components);
+            case PREFILL_DECODE       -> new PrefillDecodeForwardPlan(model, components);
+            case BATCH_PREFILL_DECODE -> new BatchPrefillDecodeForwardPlan(model, components, TornadoVMMasterPlan.PREFILL_BATCH_SIZE);
+        };
     }
 
     private static ForwardPlan createQwen3Q8_0Plan(ExecutionMode mode, Qwen3State state, Model model) {
-        if (mode != ExecutionMode.STANDARD)
-            throw new UnsupportedOperationException(mode + " not yet supported for QWEN_3 + Q8_0");
-        return new SingleTokenForwardPlan(model, new Qwen3Q8_0PlanComponents(state, model));
+        BatchPrefillDecodeForwardPlanComponents components = new Qwen3Q8_0PlanComponents(state, model);
+        return switch (mode) {
+            case STANDARD             -> new SingleTokenForwardPlan(model, components);
+            case PREFILL_DECODE       -> new PrefillDecodeForwardPlan(model, components);
+            case BATCH_PREFILL_DECODE -> new BatchPrefillDecodeForwardPlan(model, components, TornadoVMMasterPlan.PREFILL_BATCH_SIZE);
+        };
     }
 
     private static ForwardPlan createPhi3FP16Plan(ExecutionMode mode, Phi3State state, Model model) {

--- a/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/activation/BatchDecodeActivation.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/activation/BatchDecodeActivation.java
@@ -1,7 +1,7 @@
 package org.beehive.gpullama3.tornadovm.plan.components.activation;
 
-import org.beehive.gpullama3.inference.state.LlamaState;
-import org.beehive.gpullama3.model.llama.LlamaConfiguration;
+import org.beehive.gpullama3.inference.state.State;
+import org.beehive.gpullama3.model.Configuration;
 import org.beehive.gpullama3.tornadovm.kernels.TransformerComputeKernels;
 import org.beehive.gpullama3.tornadovm.layers.ActivationTaskGraph;
 import org.beehive.gpullama3.tornadovm.scheduling.WorkerGridFactory;
@@ -26,14 +26,14 @@ public class BatchDecodeActivation implements ActivationTaskGraph {
     private final ImmutableTaskGraph itg;
     private final int dim;
 
-    public BatchDecodeActivation(LlamaState state, LlamaConfiguration config, String lastBatchLayerId, boolean isQ8) {
+    public BatchDecodeActivation(State state, Configuration config, String lastBatchLayerId, boolean isQ8) {
         this.dim = config.dim();
         KernelContext ctx = new KernelContext();
         this.itg = buildGraph(ctx, state, lastBatchLayerId, isQ8).snapshot();
     }
 
     // @formatter:off
-    private TaskGraph buildGraph(KernelContext ctx, LlamaState state,
+    private TaskGraph buildGraph(KernelContext ctx, State state,
                                  String lastBatchLayerId, boolean isQ8) {
         TaskGraph tg = new TaskGraph("decodeActivation")
                 .consumeFromDevice(lastBatchLayerId, state.wrapKeyCache, state.wrapValueCache)

--- a/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/activation/BatchPrefillActivation.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/activation/BatchPrefillActivation.java
@@ -1,7 +1,7 @@
 package org.beehive.gpullama3.tornadovm.plan.components.activation;
 
-import org.beehive.gpullama3.inference.state.LlamaState;
-import org.beehive.gpullama3.model.llama.LlamaConfiguration;
+import org.beehive.gpullama3.inference.state.State;
+import org.beehive.gpullama3.model.Configuration;
 import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
 import org.beehive.gpullama3.tornadovm.kernels.TransformerComputeKernels;
 import org.beehive.gpullama3.tornadovm.layers.ActivationTaskGraph;
@@ -29,7 +29,7 @@ public class BatchPrefillActivation implements ActivationTaskGraph {
     private final int batchSize;
     private final int dim;
 
-    public BatchPrefillActivation(LlamaState state, LlamaConfiguration config, int batchSize, boolean isQ8) {
+    public BatchPrefillActivation(State state, Configuration config, int batchSize, boolean isQ8) {
         this.isQ8 = isQ8;
         this.batchSize = batchSize;
         this.dim = config.dim();
@@ -37,7 +37,7 @@ public class BatchPrefillActivation implements ActivationTaskGraph {
         this.itg = buildGraph(ctx, state).snapshot();
     }
 
-    private TaskGraph buildGraph(KernelContext ctx, LlamaState state) {
+    private TaskGraph buildGraph(KernelContext ctx, State state) {
         if (isQ8) {
             return new TaskGraph("prefillActivation")
                     .transferToDevice(DataTransferMode.EVERY_EXECUTION, state.wrapXBatch)

--- a/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/fp16/Qwen3FP16PlanComponents.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/fp16/Qwen3FP16PlanComponents.java
@@ -7,14 +7,21 @@ import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
 import org.beehive.gpullama3.tornadovm.layers.AbstractLogitsTaskGraph;
 import org.beehive.gpullama3.tornadovm.layers.Activation;
 import org.beehive.gpullama3.tornadovm.layers.ActivationTaskGraph;
+import org.beehive.gpullama3.tornadovm.layers.BatchPrefillTransformerLayerTaskGraphs;
 import org.beehive.gpullama3.tornadovm.layers.TransformerLayerTaskGraphs;
 import org.beehive.gpullama3.tornadovm.layers.type.fp16.LogitsFP16Layer;
 import org.beehive.gpullama3.tornadovm.layers.type.fp16.Qwen3FP16FFNLayers;
-import org.beehive.gpullama3.tornadovm.plan.components.SingleTokenForwardPlanComponents;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.decode.LogitsFP16LayerDecode;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.decode.Qwen3FP16FFNLayersDecode;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.decode.Qwen3FP16FFNLayersPrefillDecode;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.prefill.Qwen3FP16LayersBatchPrefill;
+import org.beehive.gpullama3.tornadovm.plan.components.BatchPrefillDecodeForwardPlanComponents;
+import org.beehive.gpullama3.tornadovm.plan.components.activation.BatchDecodeActivation;
+import org.beehive.gpullama3.tornadovm.plan.components.activation.BatchPrefillActivation;
 import org.beehive.gpullama3.tornadovm.scheduling.SchedulerDetectionService;
 import org.beehive.gpullama3.tornadovm.scheduling.SchedulerType;
 
-public class Qwen3FP16PlanComponents implements SingleTokenForwardPlanComponents {
+public class Qwen3FP16PlanComponents implements BatchPrefillDecodeForwardPlanComponents {
 
     private final Qwen3State state;
     private final Qwen3TornadoWeights weights;
@@ -28,10 +35,29 @@ public class Qwen3FP16PlanComponents implements SingleTokenForwardPlanComponents
         this.schedulerType = SchedulerDetectionService.determineSchedulerType(model);
     }
 
+    // ── Activations ───────────────────────────────────────────────────────────
+
     @Override
     public ActivationTaskGraph singleTokenActivation() {
         return new Activation("activationUpdate", state, weights, config);
     }
+
+    @Override
+    public ActivationTaskGraph prefillDecodeActivation() {
+        return new Activation("decodeActivation", state, weights, config);
+    }
+
+    @Override
+    public ActivationTaskGraph batchPrefillActivation(int batchSize) {
+        return new BatchPrefillActivation(state, config, batchSize, false);
+    }
+
+    @Override
+    public ActivationTaskGraph batchDecodeActivation(String lastBatchLayerId) {
+        return new BatchDecodeActivation(state, config, lastBatchLayerId, false);
+    }
+
+    // ── Transformer layer TaskGraphs ──────────────────────────────────────────
 
     @Override
     public TransformerLayerTaskGraphs singleTokenTransformerLayers() {
@@ -39,7 +65,29 @@ public class Qwen3FP16PlanComponents implements SingleTokenForwardPlanComponents
     }
 
     @Override
+    public TransformerLayerTaskGraphs prefillDecodeTransformerLayers() {
+        return new Qwen3FP16FFNLayersPrefillDecode("decode", state, weights, config, schedulerType);
+    }
+
+    @Override
+    public TransformerLayerTaskGraphs batchDecodeTransformerLayers() {
+        return new Qwen3FP16FFNLayersDecode("decode", state, weights, config, schedulerType);
+    }
+
+    @Override
+    public BatchPrefillTransformerLayerTaskGraphs batchPrefillTransformerLayers(int batchSize) {
+        return new Qwen3FP16LayersBatchPrefill(state, weights, config, batchSize);
+    }
+
+    // ── Logits layers ─────────────────────────────────────────────────────────
+
+    @Override
     public AbstractLogitsTaskGraph singleTokenLogits(String previousGraphId) {
         return new LogitsFP16Layer("logits", state, weights, config, previousGraphId, schedulerType);
+    }
+
+    @Override
+    public AbstractLogitsTaskGraph decodeLogits(String previousGraphId) {
+        return new LogitsFP16LayerDecode("logits", state, weights, config, previousGraphId, schedulerType);
     }
 }

--- a/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/q8_0/Qwen3Q8_0PlanComponents.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/plan/components/q8_0/Qwen3Q8_0PlanComponents.java
@@ -7,14 +7,21 @@ import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
 import org.beehive.gpullama3.tornadovm.layers.AbstractLogitsTaskGraph;
 import org.beehive.gpullama3.tornadovm.layers.Activation;
 import org.beehive.gpullama3.tornadovm.layers.ActivationTaskGraph;
+import org.beehive.gpullama3.tornadovm.layers.BatchPrefillTransformerLayerTaskGraphs;
 import org.beehive.gpullama3.tornadovm.layers.TransformerLayerTaskGraphs;
 import org.beehive.gpullama3.tornadovm.layers.type.q8_0.LogitsQ8_0Layer;
 import org.beehive.gpullama3.tornadovm.layers.type.q8_0.Qwen3Q8_0FFNLayers;
-import org.beehive.gpullama3.tornadovm.plan.components.SingleTokenForwardPlanComponents;
+import org.beehive.gpullama3.tornadovm.layers.type.q8_0.decode.LogitsQ8_0LayerDecode;
+import org.beehive.gpullama3.tornadovm.layers.type.q8_0.decode.Qwen3Q8_0FFNLayersDecode;
+import org.beehive.gpullama3.tornadovm.layers.type.q8_0.decode.Qwen3Q8_0FFNLayersPrefillDecode;
+import org.beehive.gpullama3.tornadovm.layers.type.q8_0.prefill.Qwen3Q8_0LayersBatchPrefill;
+import org.beehive.gpullama3.tornadovm.plan.components.BatchPrefillDecodeForwardPlanComponents;
+import org.beehive.gpullama3.tornadovm.plan.components.activation.BatchDecodeActivation;
+import org.beehive.gpullama3.tornadovm.plan.components.activation.BatchPrefillActivation;
 import org.beehive.gpullama3.tornadovm.scheduling.SchedulerDetectionService;
 import org.beehive.gpullama3.tornadovm.scheduling.SchedulerType;
 
-public class Qwen3Q8_0PlanComponents implements SingleTokenForwardPlanComponents {
+public class Qwen3Q8_0PlanComponents implements BatchPrefillDecodeForwardPlanComponents {
 
     private final Qwen3State state;
     private final Qwen3TornadoWeights weights;
@@ -28,10 +35,29 @@ public class Qwen3Q8_0PlanComponents implements SingleTokenForwardPlanComponents
         this.schedulerType = SchedulerDetectionService.determineSchedulerType(model);
     }
 
+    // ── Activations ───────────────────────────────────────────────────────────
+
     @Override
     public ActivationTaskGraph singleTokenActivation() {
         return new Activation("activationUpdate", state, weights, config);
     }
+
+    @Override
+    public ActivationTaskGraph prefillDecodeActivation() {
+        return new Activation("decodeActivation", state, weights, config);
+    }
+
+    @Override
+    public ActivationTaskGraph batchPrefillActivation(int batchSize) {
+        return new BatchPrefillActivation(state, config, batchSize, true);
+    }
+
+    @Override
+    public ActivationTaskGraph batchDecodeActivation(String lastBatchLayerId) {
+        return new BatchDecodeActivation(state, config, lastBatchLayerId, true);
+    }
+
+    // ── Transformer layer TaskGraphs ──────────────────────────────────────────
 
     @Override
     public TransformerLayerTaskGraphs singleTokenTransformerLayers() {
@@ -39,7 +65,29 @@ public class Qwen3Q8_0PlanComponents implements SingleTokenForwardPlanComponents
     }
 
     @Override
+    public TransformerLayerTaskGraphs prefillDecodeTransformerLayers() {
+        return new Qwen3Q8_0FFNLayersPrefillDecode("decode", state, weights, config, schedulerType);
+    }
+
+    @Override
+    public TransformerLayerTaskGraphs batchDecodeTransformerLayers() {
+        return new Qwen3Q8_0FFNLayersDecode("decode", state, weights, config, schedulerType);
+    }
+
+    @Override
+    public BatchPrefillTransformerLayerTaskGraphs batchPrefillTransformerLayers(int batchSize) {
+        return new Qwen3Q8_0LayersBatchPrefill(state, weights, config, batchSize);
+    }
+
+    // ── Logits layers ─────────────────────────────────────────────────────────
+
+    @Override
     public AbstractLogitsTaskGraph singleTokenLogits(String previousGraphId) {
         return new LogitsQ8_0Layer("logits", state, weights, config, previousGraphId, schedulerType);
+    }
+
+    @Override
+    public AbstractLogitsTaskGraph decodeLogits(String previousGraphId) {
+        return new LogitsQ8_0LayerDecode("logits", state, weights, config, previousGraphId, schedulerType);
     }
 }


### PR DESCRIPTION
## Summary

This PR extends the `prefill-decode` and `batch-prefill-decode` GPU inference paths to Qwen3 models for both FP16 and Q8_0 quantizations. It also adds corresponding coverage in CI.

The core challenge is that Qwen3 diverges from Llama in two ways that affect every attention kernel:

  - **Per-head QK RMSNorm** — Qwen3 applies a separate RMSNorm to each query and key head before RoPE. This requires a dedicated parallel reduction kernel (`Qwen3Kernels.rmsnormReductionWithParallelOffset` / 
  `rmsnormNormalisationWithParallelOffset`) and cannot reuse the scalar Llama path.
  - **GQA layout mismatch** — `Qwen3Configuration.headSize()`, `kvDim()`, and `kvMul()` throw for Qwen3 (dimensions are stored differently). All new Qwen3 layers derive head dimensions from `nEmbdHeadK` / 
  `nEmbdHeadV` / `nHeadKv` directly.
  
  ### State changes

  `State.qDim` and `State.kvDim` are made model-agnostic (previously carried Llama assumptions) so batch-prefill activations can be correctly sized for Qwen3's GQA layout. `LlamaState` and `LlamaConfiguration`
  references in batch-prefill/batch-decode activations are replaced with the base `State` and `Configuration` types.

  ## Verification

  ```bash
  export MODEL=~/LLMModels/Qwen3-0.6B-Q8_0.gguf      # or Qwen3-4B-f16.gguf
  export PROMPT="Explain Newton's second law"

  # Single-token (unchanged baseline)
  ./llama-tornado --gpu --ptx --model $MODEL --prompt "$PROMPT" --max-tokens 256

  # Prefill-decode
  ./llama-tornado --gpu --ptx --model $MODEL --prompt "$PROMPT" --max-tokens 256 \
    --with-prefill-decode

  # Batch-prefill-decode
  ./llama-tornado --gpu --ptx --model $MODEL --prompt "$PROMPT" --max-tokens 256 \
    --with-prefill-decode --batch-prefill-size 32

  # Batch-prefill-decode + CUDA graphs (PTX only)
  ./llama-tornado --gpu --ptx --model $MODEL --prompt "$PROMPT" --max-tokens 256 \
    --with-prefill-decode --batch-prefill-size 32 --cuda-graphs

  All existing Llama FP16 and Q8_0 paths (single-token, prefill-decode, batch-prefill-decode, CUDA graphs) are unaffected.

  CI

  Added CI steps for all four configurations × two quantizations, mirroring the existing Llama coverage:
  - FP16 / Q8_0 — prefill-decode and batch-prefill-decode (both backends)
  - PTX — prefill-decode-cuda-graphs and batch-prefill-decode-cuda-graphs
