### PR TITLE
Fix IllegalArgumentException (negative ArrayList capacity) on prompts longer than max-tokens

### DIFF
--- a/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
+++ b/src/main/java/org/beehive/gpullama3/inference/InferenceEngine.java
@@ -285,8 +285,10 @@ public final class InferenceEngine {
         // Pre-validate the max tokens to avoid checking in the loop
         int actualMaxTokens = Math.min(maxTokens > 0 ? maxTokens : model.configuration().contextLength(), model.configuration().contextLength());
 
-        // Preallocate with expected capacity to avoid resizing
-        List<Integer> generatedTokens = new ArrayList<>(Math.min(256, actualMaxTokens - promptTokens.size())); // Conservative estimate
+        // Preallocate with expected capacity to avoid resizing. Clamp at 0: when the
+        // prompt is longer than the token budget (actualMaxTokens), the difference is
+        // negative and would throw IllegalArgumentException("Illegal Capacity").
+        List<Integer> generatedTokens = new ArrayList<>(Math.max(0, Math.min(256, actualMaxTokens - promptTokens.size()))); // Conservative estimate
 
         // === Token Generation Loop ===
         int currentToken = state.latestToken;
@@ -373,8 +375,10 @@ public final class InferenceEngine {
         // Pre-validate the max tokens to avoid checking in the loop
         int actualMaxTokens = Math.min(maxTokens > 0 ? maxTokens : model.configuration().contextLength(), model.configuration().contextLength());
 
-        // Preallocate with expected capacity to avoid resizing
-        List<Integer> generatedTokens = new ArrayList<>(Math.min(256, actualMaxTokens - promptTokens.size())); // Conservative estimate
+        // Preallocate with expected capacity to avoid resizing. Clamp at 0: when the
+        // prompt is longer than the token budget (actualMaxTokens), the difference is
+        // negative and would throw IllegalArgumentException("Illegal Capacity").
+        List<Integer> generatedTokens = new ArrayList<>(Math.max(0, Math.min(256, actualMaxTokens - promptTokens.size()))); // Conservative estimate
 
         // Initialize token variables
         int currentToken = state.latestToken; // BOS?


### PR DESCRIPTION
#### Description

Fixes a crash when the prompt is longer than the generation token budget.

`InferenceEngine.generateTokens*` preallocates the output list with:

```java
new ArrayList<>(Math.min(256, actualMaxTokens - promptTokens.size()));
```

When `promptTokens.size() > actualMaxTokens` (a long prompt with a small `-n` / `--max-tokens`), `actualMaxTokens - promptTokens.size()` is negative, so `new ArrayList<>(negative)` throws:

```
java.lang.IllegalArgumentException: Illegal Capacity: -883
    at org.beehive.gpullama3.inference.InferenceEngine.generateTokensGPULlama(InferenceEngine.java:289)
```

Fix: clamp the capacity at 0 with `Math.max(0, ...)` in both generation paths.

#### Repro

```
llama-tornado --gpu --cuda --model beehive-llama-3.2-1b-instruct-fp16.gguf \
  --prompt "<~900-token prompt>" -n 48 --instruct
```

Before: `IllegalArgumentException: Illegal Capacity`. After: generates normally (verified: correct output, no crash, on an RTX 4090 / CUDA backend). Short prompts unaffected (e.g. "What is 2+2?" → "2 + 2 = 4").
