### PR TITLE
Fix Qwen3 FP16 garbage on CUDA backend: cross-workgroup race in RMS-norm reduction

### DIFF
--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerComputeKernelsLayered.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerComputeKernelsLayered.java
@@ -2489,6 +2489,44 @@ public class TransformerComputeKernelsLayered {
         return localSum[0];
     }
 
+    /**
+     * Race-free RMS-norm reduction in ONE workgroup: threads stride over the input, reduce in
+     * local memory, and lane 0 writes the final scale factor to {@code output[0]}.
+     *
+     * <p>The multi-workgroup variant ({@code reductionOneBlockWithLayer}) has workgroup 0
+     * combining the other workgroups' partial sums with <em>no inter-workgroup
+     * synchronization</em> — a data race. On the CUDA backend the race outcome is
+     * schedule/compilation dependent: e.g. Qwen3-1.7B reads stale partials on every layer
+     * (wrong normalization scale → garbage output) while Llama-1B and Qwen3-4B happen to win
+     * the race. The NON_NVIDIA scheduler avoids the race with a separate
+     * {@code reductionFinalNormalization} task; this kernel is the NVIDIA-path equivalent.
+     * Launch with exactly one workgroup: {@code global == local == localMemSize}.</p>
+     */
+    public static void reductionOneBlockWithLayerSingleGroup(KernelContext context, FloatArray output, FloatArray x, int size, float ermsNorm, int localMemSize) {
+        int lid = context.localIdx;
+        int groupSize = context.localGroupSizeX;
+        float[] localX = context.allocateFloatLocalArray(localMemSize);
+
+        float partial = 0.0f;
+        for (int j = lid; j < size; j += groupSize) {
+            float v = x.get(j);
+            partial += v * v;
+        }
+        localX[lid] = partial;
+
+        for (int stride = groupSize / 2; stride > 0; stride /= 2) {
+            context.localBarrier();
+            if (lid < stride) {
+                localX[lid] += localX[lid + stride];
+            }
+        }
+
+        if (lid == 0) {
+            float ss = localX[0] / size + ermsNorm;
+            output.set(0, 1.0f / TornadoMath.sqrt(ss));
+        }
+    }
+
     // Second kernel - Combines partial sums and computes final normalization
     public static void reductionFinalNormalization(KernelContext context, FloatArray output, int size, float ermsNorm) {
         int gid = context.globalIdx;

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/Qwen3FP16FFNLayers.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/Qwen3FP16FFNLayers.java
@@ -59,6 +59,8 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
     @Override
     public GridScheduler updateGridScheduler(GridScheduler gridScheduler) {
         WorkerGrid rmsNormWorker = WorkerGridFactory.createRmsNormWorker(config.dim(), state.localSize);
+        // Single-workgroup grid for the race-free NVIDIA-path RMS reduction (global == local).
+        WorkerGrid rmsSingleGroupWorker = WorkerGridFactory.createRmsNormWorker(state.localSize, state.localSize);
         WorkerGrid ropeWorker = WorkerGridFactory.createRoPEWorker(config.numberOfHeads(), nEmbdHead);
         // Split-KV attention launches nHeads*nSplits workgroups (one per head-split) followed by a combine
         // pass over nHeads workgroups.
@@ -85,7 +87,8 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
         // Map workers to tasks for each layer (in task execution order)
         for (int i = 0; i < config.numberOfLayers(); i++) {
             // === Attention Block ===
-            gridScheduler.addWorkerGrid("layer_" + i + ".attn_rms_reduce", rmsNormWorker);
+            gridScheduler.addWorkerGrid("layer_" + i + ".attn_rms_reduce",
+                    shouldUseFinalNormalization() ? rmsNormWorker : rmsSingleGroupWorker);
             gridScheduler.addWorkerGrid("layer_" + i + ".attn_rms_qkv_projection", fusedQKVWorker);
             gridScheduler.addWorkerGrid("layer_" + i + ".qk_rmsnorm", qkRmsNormWorker);
             gridScheduler.addWorkerGrid("layer_" + i + ".rope_and_kv_cache", ropeWorker);
@@ -93,7 +96,8 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
             gridScheduler.addWorkerGrid("layer_" + i + ".attention_combine", attentionCombineWorker);
             gridScheduler.addWorkerGrid("layer_" + i + ".attn_output_proj", matmul1Worker);
             // === FFN Block ===
-            gridScheduler.addWorkerGrid("layer_" + i + ".ffn_rms_reduce", rmsNormWorker);
+            gridScheduler.addWorkerGrid("layer_" + i + ".ffn_rms_reduce",
+                    shouldUseFinalNormalization() ? rmsNormWorker : rmsSingleGroupWorker);
             if (shouldUseFinalNormalization()) {
                 gridScheduler.addWorkerGrid("layer_" + i + ".ffn_rms_finalize", rmsNormWorker);
             }
@@ -230,6 +234,18 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
         // ═══════════════════════════════════════════════════════════════════════
 
         // RMS Normalization - compute scale factor
+        if (!shouldUseFinalNormalization()) {
+            // NVIDIA path: single-workgroup reduction. The multi-workgroup kernel relies on a
+            // racy cross-workgroup combine (no finalize task on this path) — see kernel javadoc.
+            unifiedLayer.task("attn_rms_reduce",
+                    TransformerComputeKernelsLayered::reductionOneBlockWithLayerSingleGroup,
+                    context,
+                    qwen3State.temp,
+                    qwen3State.wrapX,
+                    config.dim(),
+                    config.rmsNormEps(),
+                    qwen3State.localSize);
+        } else
         unifiedLayer.task("attn_rms_reduce",
                 TransformerComputeKernelsLayered::reductionOneBlockWithLayer,
                 context,
@@ -361,6 +377,17 @@ public class Qwen3FP16FFNLayers extends AbstractTransformerLayerTaskGraphs<Qwen3
         // ═══════════════════════════════════════════════════════════════════════
 
         // RMS Normalization - compute scale factor
+        if (!shouldUseFinalNormalization()) {
+            // NVIDIA path: single-workgroup reduction (race-free) — see attn_rms_reduce.
+            unifiedLayer.task("ffn_rms_reduce",
+                    TransformerComputeKernelsLayered::reductionOneBlockWithLayerSingleGroup,
+                    context,
+                    qwen3State.tempFFN,
+                    qwen3State.wrapX,
+                    config.dim(),
+                    config.rmsNormEps(),
+                    qwen3State.localSize);
+        } else
         unifiedLayer.task("ffn_rms_reduce",
                 TransformerComputeKernelsLayered::reductionOneBlockWithLayer,
                 context,


### PR DESCRIPTION
## Fix: Qwen3 FP16 emits garbage on the CUDA backend — cross-workgroup data race in the RMS-norm reduction

**Symptom.** Qwen3-1.7B FP16 single-token decode on the CUDA backend produces garbage (endless `\n` + stray tokens, argmax stuck) from the first sampled token; Qwen3-4B works. Deterministic, both CUDA-graph modes.

**Root cause.** `reductionOneBlockWithLayer` writes each workgroup's partial sum to `output[groupId+1]`, then thread `gid==0` (workgroup 0) sums `output[1..N]` **in the same kernel with no inter-workgroup synchronization or memory fence** — a data race. On the NON_NVIDIA scheduler this race doesn't exist (a separate `reductionFinalNormalization` task combines the partials); the NVIDIA path skips that task and relies on the racy in-kernel combine. Whether the race is lost is schedule/compilation dependent: Llama-1B and Qwen3-4B happen to win it, Qwen3-1.7B deterministically loses it — every layer's RMS-norm scale is computed from stale partials, corrupting the hidden state everywhere at once.

**Diagnosis** (bisection, all on RTX 4090, TornadoVM 5.0.1-jdk21-dev CUDA backend):
- Batched-decode Qwen3 path (PR #129 kernels) = coherent with the same weights → weights/tokenizer/logits fine.
- Batch-prefill mode produced the correct first token (`<think>`), then the decode graph degraded → single-token layer graph implicated.
- Swapped every Qwen3-specific fused kernel (QKV matmul, Q/K per-head norm, RoPE, split-KV attention) for plain `@Parallel` reference implementations → still garbage.
- Swapped the RMS reductions alone → **correct output, exact logits match with the all-reference run** (`argmax='<think>'`, host-recomputed logits ≡ GPU logits).

**Fix.** New `reductionOneBlockWithLayerSingleGroup`: one workgroup strides over the input, reduces in local memory, lane 0 writes the final scale — race-free by construction, one kernel, no extra launch. The Qwen3 FP16 layer graphs use it on the NVIDIA scheduler path (grid `global == local == localSize`); the NON_NVIDIA path keeps the existing partials + finalize pair.

**Verified** (all coherent, greedy):
| model | before | after |
|---|---|---|
| Qwen3-1.7B FP16 | garbage (`\n\n\n…9…avier`) | `<think> Okay, the user is asking for the capital of France… Paris` (matches the validated batched-decode output) |
| Qwen3-1.7B + CUDA graphs | garbage | coherent |
| Qwen3-4B | coherent | coherent (unchanged) |
| Llama-3.2-1B / Mistral-7B | coherent | coherent (path untouched) |

Perf unchanged: Qwen3-1.7B ~51 tok/s, Llama-1B ~90 tok/s before/after.

**Note.** The same racy combine is still used by the Llama layer graphs and the logits layer (`TransformerComputeKernels.reductionOneBlockWithLayer`) — they currently win the race on this hardware, but they are latent instances of the same bug class; happy to extend the fix there if you want it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
